### PR TITLE
Fixes single result redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Tranga can download Chapters and Metadata from "Scanlation" sites such as
 - [MangaDex.org](https://mangadex.org/)
 - [Manganato.com](https://manganato.com/)
 - [Mangasee](https://mangasee123.com/)
+- [MangaKatana](https://mangakatana.com)
 - ❓ Open an [issue](https://github.com/C9Glax/tranga/issues)
 
 and automatically import them with [Komga](https://komga.org/) and [Kavita](https://www.kavitareader.com/). Also Notifications will be sent to your devices using [Gotify](https://gotify.net/) and [LunaSea](https://www.lunasea.app/).

--- a/Tranga-CLI/Tranga_Cli.cs
+++ b/Tranga-CLI/Tranga_Cli.cs
@@ -504,8 +504,30 @@ public static class Tranga_Cli
         Chapter[] availableChapters = connector.GetChapters(publication, "en");
         int cIndex = 0;
         Console.WriteLine("Chapters:");
+        
+        System.Text.StringBuilder sb = new();
         foreach(Chapter chapter in availableChapters)
-            Console.WriteLine($"{cIndex++}: Vol.{chapter.volumeNumber} Ch.{chapter.chapterNumber} - {chapter.name}");
+        {
+            sb.Append($"{cIndex++}: ");
+
+            if(string.IsNullOrWhiteSpace(chapter.volumeNumber) == false)
+            {
+                sb.Append($"Vol.{chapter.volumeNumber} ");
+            }
+
+            if(string.IsNullOrWhiteSpace(chapter.chapterNumber) == false)
+            {
+                sb.Append($"Ch.{chapter.chapterNumber} ");
+            }
+
+            if(string.IsNullOrWhiteSpace(chapter.name) == false)
+            {
+                sb.Append($" - {chapter.name}");
+            }
+
+            Console.WriteLine(sb.ToString());
+            sb.Clear();
+        }
         
         Console.WriteLine("Enter q to abort");
         Console.WriteLine($"Select Chapter(s):");


### PR DESCRIPTION
Should fix #27 

It will skip scanning the result page, and just goes to parsing the result page. The results will only show 1 result then, but i decided to keep it like that to keep it in line with other Connectors, minimize changes to the CLI process and so the user can verify the result.

Some additional changes came with it due to this:

* RequestResult has a property that indicates if the request has been redirected (and to which url). Although it's a bit naive, but it should be good enough for now.
* The testcase (I wanna quit being a hitman!) had no chapter and volume names, only numbers. The cli app takes this into account now