### PR TITLE
Automatic build of Docker images for many platforms (ARM too)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,73 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # https://github.com/docker/setup-qemu-action#usage
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.2.0
+
+      # https://github.com/marketplace/actions/docker-setup-buildx
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2.9.1
+      
+      # https://github.com/docker/login-action#docker-hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      # https://github.com/docker/build-push-action#multi-platform-image
+      - name: Build and push base
+        uses: docker/build-push-action@v4.1.1
+        with:
+          context: ./
+          file: ./Dockerfile-base
+          #platforms: linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          pull: true
+          push: true
+          tags: |
+            glax/tranga-base:latest
+      
+      # https://github.com/docker/build-push-action#multi-platform-image
+      - name: Build and push API
+        uses: docker/build-push-action@v4.1.1
+        with:
+          context: ./API
+          file: ./API/Dockerfile
+          #platforms: linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          pull: true
+          push: true
+          tags: |
+            glax/tranga-api:latest
+      
+      # https://github.com/docker/build-push-action#multi-platform-image
+      - name: Build and push Website
+        uses: docker/build-push-action@v4.1.1
+        with:
+          context: ./Website
+          file: ./Website/Dockerfile
+          #platforms: linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          pull: true
+          push: true
+          tags: |
+            glax/tranga-website:latest


### PR DESCRIPTION
Solves https://github.com/C9Glax/tranga/issues/6?

## IMPORTANT
Make sure to setup [personal access tokens](https://docs.docker.com/docker-hub/access-tokens/) `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as documented on https://github.com/docker/login-action#docker-hub

This will build Docker images of base, website, api, on pushes and pulls on your master branch, and you can trigger a build manually in the `Action` tab of this repo (https://github.com/C9Glax/tranga/actions).