### PR TITLE
Added check to prevent creation of empty chapter files

### DIFF
--- a/Tranga/MangaConnectors/MangaConnector.cs
+++ b/Tranga/MangaConnectors/MangaConnector.cs
@@ -241,6 +241,15 @@ public abstract class MangaConnector : GlobalBase
 
         int chapter = 0;
         //Download all Images to temporary Folder
+        if (imageUrls.Length == 0)
+        {
+            Log("No images found");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                File.SetUnixFileMode(saveArchiveFilePath, UserRead | UserWrite | UserExecute | GroupRead | GroupWrite | GroupExecute);
+            Directory.Delete(tempFolder, true);
+            progressToken?.Complete();
+            return HttpStatusCode.NoContent;
+        }
         foreach (string imageUrl in imageUrls)
         {
             string extension = imageUrl.Split('.')[^1].Split('?')[0];

--- a/Tranga/MangaConnectors/Mangasee.cs
+++ b/Tranga/MangaConnectors/Mangasee.cs
@@ -199,8 +199,8 @@ public class Mangasee : MangaConnector
                 string? volumeNumber = m.Groups[2].Success ? m.Groups[2].Value : "1";
                 string chapterNumber = m.Groups[1].Value;
 
-                url = string.Concat(Regex.Match(url, @"(.*)-page-[0-9]+(\.html)").Groups.Values.Select(v => v.Value));
-                chapters.Add(new Chapter(manga, "", volumeNumber, chapterNumber, url));
+                string chapterUrl = Regex.Replace(url, @"-page-[0-9]+(\.html)", ".html");
+                chapters.Add(new Chapter(manga, "", volumeNumber, chapterNumber, chapterUrl));
             }
 
             //Return Chapters ordered by Chapter-Number


### PR DESCRIPTION
@C9Glax I noticed that Mangasee was creating empty chapter files for some chapters so I added a check to make sure we don't create empty archives. It's my first time working with C# so I'll need you to review this to make sure it looks fine. 

I'm still not sure why Mangasee gets hung up after the "Page loaded." message, so if you have any ideas, I'm all ears.

Potential fix for part of https://github.com/C9Glax/tranga/issues/138#issuecomment-1979934025