### PR TITLE
MangaDex request limit change

### DIFF
--- a/Tranga/MangaConnectors/RequestType.cs
+++ b/Tranga/MangaConnectors/RequestType.cs
@@ -6,7 +6,6 @@ public enum RequestType : byte
     MangaDexFeed = 1,
     MangaImage = 2,
     MangaCover = 3,
-    MangaDexAuthor = 4, //Legacy
     MangaDexImage = 5,
     MangaInfo = 6
 }

--- a/Tranga/MangaConnectors/RequestType.cs
+++ b/Tranga/MangaConnectors/RequestType.cs
@@ -6,7 +6,7 @@ public enum RequestType : byte
     MangaDexFeed = 1,
     MangaImage = 2,
     MangaCover = 3,
-    MangaDexAuthor = 4,
+    MangaDexAuthor = 4, //Legacy
     MangaDexImage = 5,
     MangaInfo = 6
 }

--- a/Tranga/TrangaSettings.cs
+++ b/Tranga/TrangaSettings.cs
@@ -1,4 +1,6 @@
 ﻿using System.Runtime.InteropServices;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Tranga.LibraryConnectors;
 using Tranga.MangaConnectors;
@@ -19,7 +21,7 @@ public class TrangaSettings
     [JsonIgnore] public string jobsFolderPath => Path.Join(workingDirectory, "jobs");
     [JsonIgnore] public string coverImageCache => Path.Join(workingDirectory, "imageCache");
     [JsonIgnore] internal static readonly string DefaultUserAgent = $"Tranga ({Enum.GetName(Environment.OSVersion.Platform)}; {(Environment.Is64BitOperatingSystem ? "x64" : "")}) / 1.0";
-    public ushort? version { get; } = 1;
+    public ushort? version { get; } = 2;
     public bool aprilFoolsMode { get; private set; } = true;
     [JsonIgnore]internal static readonly Dictionary<RequestType, int> DefaultRequestLimits = new ()
     {
@@ -43,6 +45,7 @@ public class TrangaSettings
         {//Load from settings file
             FileStream lockFile = File.Create(lockFilePath,0, FileOptions.DeleteOnClose); //lock settingsfile
             string settingsStr = File.ReadAllText(sfp);
+            settingsStr = Regex.Replace(settingsStr, @"""MangaDexAuthor"": [0-9]+,", "");//https://github.com/C9Glax/tranga/pull/161 Remove sometime in the future :3
             TrangaSettings settings = JsonConvert.DeserializeObject<TrangaSettings>(settingsStr)!;
             this.requestLimits = settings.requestLimits;
             this.userAgent = settings.userAgent;

--- a/Tranga/TrangaSettings.cs
+++ b/Tranga/TrangaSettings.cs
@@ -28,7 +28,6 @@ public class TrangaSettings
         {RequestType.MangaDexImage, 40},
         {RequestType.MangaImage, 60},
         {RequestType.MangaCover, 250},
-        {RequestType.MangaDexAuthor, 250}, //Legacy
         {RequestType.Default, 60}
     };
 

--- a/Tranga/TrangaSettings.cs
+++ b/Tranga/TrangaSettings.cs
@@ -28,7 +28,7 @@ public class TrangaSettings
         {RequestType.MangaDexImage, 40},
         {RequestType.MangaImage, 60},
         {RequestType.MangaCover, 250},
-        {RequestType.MangaDexAuthor, 250},
+        {RequestType.MangaDexAuthor, 250}, //Legacy
         {RequestType.Default, 60}
     };
 


### PR DESCRIPTION
With https://github.com/C9Glax/tranga/commit/8f8d0198616323d1fe1d6af461837270ea32f5a0 the [RequestType](https://github.com/C9Glax/tranga/blob/master/Tranga/MangaConnectors/RequestType.cs) `MangaDexAuthor` is no longer required.

Merge when Website is ready.

Closes C9Glax/tranga-website#80