### PR TITLE
Fix the Webtoons connector getting few chapters multiple times

### DIFF
--- a/Tranga/MangaConnectors/Webtoons.cs
+++ b/Tranga/MangaConnectors/Webtoons.cs
@@ -154,15 +154,16 @@ public class Webtoons : MangaConnector
             return Array.Empty<Chapter>();
 
         // Get number of pages
-        int pages = requestResult.htmlDocument.DocumentNode.SelectSingleNode("//div[contains(@class, 'paginate')]").ChildNodes.ToArray().Length;
+        int pages = requestResult.htmlDocument.DocumentNode
+                            .SelectNodes("//div[contains(@class, 'paginate')]/a")
+                            .ToList()
+                            .Count;
         List<Chapter> chapters = new List<Chapter>();
         
         for(int page = 1; page <= pages; page++) {
             string pageRequestUrl = $"{requestUrl}&page={page}";
-
             chapters.AddRange(ParseChaptersFromHtml(manga, pageRequestUrl));
         }
-
         Log($"Got {chapters.Count} chapters. {manga}");
         return chapters.Order().ToArray();
     }


### PR DESCRIPTION
- fixed when parsing chapters the pages was incorrectly parsed resulting into adding the chapters from the last page multiple times (was still downloading OK but it would try to download the chapters from last page multiple times)


PS. I found this when requesting the chapter list for my webpage rework (I mentioned earlier) and found that the toon was returning some chapters multiple times (with same parameters).