### PR TITLE
Weebcentral: File name also depends on original chapter name

### DIFF
--- a/Tranga/Chapter.cs
+++ b/Tranga/Chapter.cs
@@ -96,17 +96,15 @@ public readonly struct Chapter : IComparable
         if(mangaArchive is null)
         {
             FileInfo[] archives = new DirectoryInfo(mangaDirectory).GetFiles("*.cbz");
-            Regex volChRex = new(@"(?:Vol(?:ume)?\.([0-9]+)\D*)?Ch(?:apter)?\.([0-9]+(?:\.[0-9]+)*)");
+            Regex volChRex = new(@"(?:Vol(?:ume)?\.([0-9]+)\D*)?Ch(?:apter)?\.([0-9]+(?:\.[0-9]+)*)(?: - (.*))?.cbz");
 
             Chapter t = this;
             mangaArchive = archives.FirstOrDefault(archive =>
             {
                 Match m = volChRex.Match(archive.Name);
-                if (m.Groups[1].Success)
-                    return m.Groups[1].Value == t.volumeNumber.ToString(GlobalBase.numberFormatDecimalPoint) &&
-                           m.Groups[2].Value == t.chapterNumber.ToString(GlobalBase.numberFormatDecimalPoint);
-                else
-                    return m.Groups[2].Value == t.chapterNumber.ToString(GlobalBase.numberFormatDecimalPoint);
+                return (!m.Groups[1].Success || m.Groups[1].Value == t.volumeNumber.ToString(GlobalBase.numberFormatDecimalPoint)) &&
+                       m.Groups[2].Value == t.chapterNumber.ToString(GlobalBase.numberFormatDecimalPoint) &&
+                       (t.name == null || m.Groups[3].Value == t.name);
             });
         }
         

--- a/Tranga/Chapter.cs
+++ b/Tranga/Chapter.cs
@@ -44,7 +44,7 @@ public readonly struct Chapter : IComparable
         if (name is not null && name.Length > 0)
         {
             string chapterName = IllegalStrings.Replace(string.Concat(LegalCharacters.Matches(name)), "");
-            this.fileName = $"{chapterVolNumStr} - {chapterName}";
+            this.fileName = chapterName.Length > 0 ? $"{chapterVolNumStr} - {chapterName}" : chapterVolNumStr;
         }
         else
             this.fileName = chapterVolNumStr;

--- a/Tranga/Chapter.cs
+++ b/Tranga/Chapter.cs
@@ -102,9 +102,14 @@ public readonly struct Chapter : IComparable
             mangaArchive = archives.FirstOrDefault(archive =>
             {
                 Match m = volChRex.Match(archive.Name);
+                /*
+                 * 1. If the volumeNumber is not present in the filename, it is not checked.
+                 * 2. Check the chapterNumber in the chapter against the one in the filename.
+                 * 3. The chpaterName has to either be absent both in the chapter and the filename or match.
+                 */
                 return (!m.Groups[1].Success || m.Groups[1].Value == t.volumeNumber.ToString(GlobalBase.numberFormatDecimalPoint)) &&
                        m.Groups[2].Value == t.chapterNumber.ToString(GlobalBase.numberFormatDecimalPoint) &&
-                       (t.name == null || m.Groups[3].Value == t.name);
+                       ((!m.Groups[3].Success && string.IsNullOrEmpty(t.name)) || m.Groups[3].Value == t.name);
             });
         }
         

--- a/Tranga/MangaConnectors/WeebCentral.cs
+++ b/Tranga/MangaConnectors/WeebCentral.cs
@@ -164,10 +164,14 @@ public class Weebcentral : MangaConnector
             string chapterNode = elem.SelectSingleNode("span[@class='grow flex items-center gap-2']/span")?.InnerText ??
                                  "Undefined";
 
-            Match chapterNumberMatch = chapterRex.Match(chapterNode);
-            string chapterNumber = chapterNumberMatch.Success ? chapterNumberMatch.Groups[1].Value : "-1";
-            Match chapterNameMatch = chapterNameRex.Match(chapterNode);
-            string chapterName = chapterNameMatch.Success ? chapterNameMatch.Groups[1].Value.Trim() : "";
+            MatchCollection chapterNumberMatch = chapterRex.Matches(chapterNode);
+            string chapterNumber = chapterNumberMatch.Count > 0 ? chapterNumberMatch[^1].Groups[1].Value : "-1";
+            MatchCollection chapterNameMatch = chapterNameRex.Matches(chapterNode);
+            string chapterName = chapterNameMatch.Count > 0
+                ? string.Join(" - ",
+                    chapterNameMatch.Select(m => m.Groups[1].Value.Trim())
+                        .Where(name => name.Length > 0 && !name.Equals("Chapter", StringComparison.OrdinalIgnoreCase)).ToArray()).Trim()
+                : "";
 
             return new Chapter(manga, chapterName != "" ? chapterName : null, null, chapterNumber, url, id);
         }).Where(elem => elem.chapterNumber != -1 && elem.url != "undefined").ToList();

--- a/Tranga/MangaConnectors/WeebCentral.cs
+++ b/Tranga/MangaConnectors/WeebCentral.cs
@@ -140,7 +140,7 @@ public class Weebcentral : MangaConnector
             return [];
         List<Chapter> chapters = ParseChaptersFromHtml(manga, requestResult.htmlDocument);
         Log($"Got {chapters.Count} chapters. {manga}");
-        return chapters.OrderBy(c => c.name).ThenBy(c => c.volumeNumber).ThenBy(c => c.chapterNumber).ToArray();
+        return chapters.OrderByDescending(c => c.name).ThenBy(c => c.volumeNumber).ThenBy(c => c.chapterNumber).ToArray();
     }
 
     private List<Chapter> ParseChaptersFromHtml(Manga manga, HtmlDocument document)


### PR DESCRIPTION
Should close #352 

I added chapter name generation based on the name used in Weebcentral.
This generates the following outcome:
- Original ch name -> file name
- Chapter X -> Vol.0 Ch.X (maintains old naming to prevent the need to redownload everything)
- [SOMETHING] X -> Vol.0 Ch.X - [SOMETHING]
- [SOMETHING] - [SOMETHING1] X -> Vol.0 Ch.X - [SOMETHING] - [SOMETHING1] (Should help with seasonal weebtoons)

@C9Glax what do you think about this? Could it create problems with frontend?

EDIT: This should also contribute to #332 