### PR TITLE
Enforce correct referrer check for access to Manganato

### DIFF
--- a/Tranga/MangaConnectors/Manganato.cs
+++ b/Tranga/MangaConnectors/Manganato.cs
@@ -212,7 +212,7 @@ public class Manganato : MangaConnector
 
         string[] imageUrls = ParseImageUrlsFromHtml(requestResult.htmlDocument);
         
-        return DownloadChapterImages(imageUrls, chapter, RequestType.MangaImage, "https://chapmanganato.com/", progressToken:progressToken);
+        return DownloadChapterImages(imageUrls, chapter, RequestType.MangaImage, "https://www.manganato.gg", progressToken:progressToken);
     }
 
     private string[] ParseImageUrlsFromHtml(HtmlDocument document)


### PR DESCRIPTION
It appears that since my previous PR, a change has been made regarding allowed connection sources. The site now verifies whether the request originates from https://www.manganato.gg and no longer allows access to the page without the correct referrer.
Apologies for the quick follow-up PR! I hope this will be the last change needed for a while.