### PR TITLE
Manganato fix chapter naming format in CBZ files (i am sorry)

### DIFF
--- a/Tranga/MangaConnectors/Manganato.cs
+++ b/Tranga/MangaConnectors/Manganato.cs
@@ -167,8 +167,9 @@ public class Manganato : MangaConnector
         foreach (HtmlNode chapterInfo in chapterList.Descendants("div").Where(x => x.HasClass("row")))
         {
             string url = chapterInfo.Descendants("a").First().GetAttributeValue("href", "");
-            string chapterName = chapterInfo.Descendants("a").First().GetAttributeValue("title", "");
-            string chapterNumber = Regex.Match(chapterName, @"Chapter ([0-9]+(\.[0-9]+)*)").Groups[1].Value;
+            var name = chapterInfo.Descendants("a").First().InnerText.Trim();
+            string chapterName = nameRex.Match(name).Groups[3].Value;
+            string chapterNumber = Regex.Match(name, @"Chapter ([0-9]+(\.[0-9]+)*)").Groups[1].Value;
             string? volumeNumber = Regex.Match(chapterName, @"Vol\.([0-9]+)").Groups[1].Value;
             if (string.IsNullOrWhiteSpace(volumeNumber))
                 volumeNumber = "0";


### PR DESCRIPTION
I sincerely apologize for yet another PR this time, I realized I messed up the chapter naming format. I've fixed the issue in this PR.

I just realized that parsing the chapterName through the nameRex regex was needed, but I didn't catch this in my last PR. As a result, the name incorrectly appended to the end of the filename.

Again, I'm really sorry for the back-to-back PRs due to my own mistakes—I appreciate your patience, and I’ll do my best to avoid these kinds of errors in the future!

It caused it to create files like so
![image](https://github.com/user-attachments/assets/6660d4f6-4b7e-48f9-b9a0-f4370d53970c)
which now should generate like so
![image](https://github.com/user-attachments/assets/e4298d71-8572-4a3a-9e68-fc7685fc8c57)