### PR TITLE
Wait for Postgres healthcheck before attempting to continue

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -11,7 +11,8 @@ services:
     ports:
       - "6531:6531"
     depends_on:
-      - tranga-pg
+      tranga-pg:
+        condition: service_healthy
     environment:
       - POSTGRES_HOST=tranga-pg
     restart: unless-stopped
@@ -22,4 +23,10 @@ services:
       - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 30s
+      timeout: 60s
+      retries: 5
+      start_period: 80s
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-﻿version: '3'
+version: '3'
 services:
   tranga-api:
     image: glax/tranga-api:latest
@@ -9,7 +9,8 @@ services:
     ports:
       - "6531:6531"
     depends_on:
-      - tranga-pg
+      tranga-pg:
+        condition: service_healthy
     environment:
       - POSTGRES_HOST=tranga-pg
     restart: unless-stopped
@@ -28,4 +29,10 @@ services:
       - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 30s
+      timeout: 60s
+      retries: 5
+      start_period: 80s
     restart: unless-stopped


### PR DESCRIPTION
This may be due to a behaviour difference between Docker and Podman, but I was having problems the API container attempting to finish setup before Postgres had fully started. I was able to fix that be adding a healthcheck to `tranga-pg` and then having `tranga-api` depend on the healthcheck rather than the Postgres container itself.