### PR TITLE
[V2] BUGFIX: JsonException not caught if response is not JSON

### DIFF
--- a/API/MangaDownloadClients/FlareSolverrDownloadClient.cs
+++ b/API/MangaDownloadClients/FlareSolverrDownloadClient.cs
@@ -172,6 +172,10 @@ public class FlareSolverrDownloadClient : DownloadClient
             jsonString = pre.InnerText;
             return true;
         }
+        catch (System.Text.Json.JsonException)
+        {
+            return false;
+        }
         catch (JsonReaderException)
         {
             return false;


### PR DESCRIPTION
This PR fixes #423 where JsonException wouldn't be caught and triggered a 500 error