### PR TITLE
Fix Mangaworld connector: include .jpeg images

### DIFF
--- a/API/MangaConnectors/Mangaworld.cs
+++ b/API/MangaConnectors/Mangaworld.cs
@@ -233,7 +233,7 @@ public sealed class Mangaworld : MangaConnector
                 return list;
             })
             .Select(x => MakeAbsoluteUrl(baseUri, x))
-            .Where(u => u.ToLowerInvariant().StartsWith("http") && (u.EndsWith(".jpg") || u.EndsWith(".png") || u.EndsWith(".webp")));
+            .Where(u => u.ToLowerInvariant().StartsWith("http") && (u.EndsWith(".jpg") || u.EndsWith(".jpeg") || u.EndsWith(".png") || u.EndsWith(".webp")));
 
         return fromDom.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }


### PR DESCRIPTION
### Summary

Some Mangaworld chapters have all their page images served as `.jpeg` instead of `.jpg` / `.png` / `.webp`.
The current connector filters chapter image URLs by extension and skips `.jpeg`, which results in:

- `GetChapterImageUrls` returning an empty array for those chapters
- `DownloadChapterFromMangaconnectorWorker` running with `0` images and producing empty or missing CBZ files

### Changes

In `API/MangaConnectors/Mangaworld.cs`:

- Updated the extension filter in `GetChapterImageUrls` to also accept `.jpeg`:

```csharp
.Where(u => u.ToLowerInvariant().StartsWith("http") &&
            (u.EndsWith(".jpg") || u.EndsWith(".jpeg") || u.EndsWith(".png") || u.EndsWith(".webp")));
