### PR TITLE
Fix MangaDex unavailable chapters

### DIFF
--- a/API/MangaConnectors/MangaDex.cs
+++ b/API/MangaConnectors/MangaDex.cs
@@ -133,10 +133,13 @@ public class MangaDex : MangaConnector
         int total = int.MaxValue;
         while(offset < total)
         {
+            // https://api.mangadex.org/docs/redoc.html#tag/Manga/operation/get-manga-id-feed
             string requestUrl =
                 $"https://api.mangadex.org/manga/{mangaId.IdOnConnectorSite}/feed?limit={Limit}&offset={offset}&" +
                 $"translatedLanguage%5B%5D={language}&" +
-                $"contentRating%5B%5D=safe&contentRating%5B%5D=suggestive&contentRating%5B%5D=erotica&includeFutureUpdates=0&includes%5B%5D=";
+                $"contentRating%5B%5D=safe&contentRating%5B%5D=suggestive&contentRating%5B%5D=erotica&" +
+                $"includeFutureUpdates=0&includes%5B%5D=&" +
+                $"includeEmptyPages=0"; // remove entries with no available pages e.g. externally hosted chapters
             offset += Limit;
 
             HttpResponseMessage result = downloadClient.MakeRequest(requestUrl, RequestType.MangaDexFeed).Result;


### PR DESCRIPTION
Fixes a bug in the MangaDex connector which returned externally hosted chapters, which would be picked as a download source, despite not being supported and alternatives being available.