### PR TITLE
WeebCentral - Fix volMatch regex

### DIFF
--- a/API/MangaConnectors/WeebCentral.cs
+++ b/API/MangaConnectors/WeebCentral.cs
@@ -215,7 +215,7 @@ public class WeebCentral : MangaConnector
 
 			// Get volume/season number - if applicable
 			int? volumeNumber = null;
-			Match volMatch = Regex.Match(text, @"(?:volume|vol\.?|season|s\.?)\s*([\d]?)", RegexOptions.IgnoreCase);
+			Match volMatch = Regex.Match(text, @"^(?:volume|vol\.?|season|s\.?)\s*([\d]+)", RegexOptions.IgnoreCase);
 			if (volMatch.Success)
 			{
 				if (int.TryParse(volMatch.Groups[1].Value, out int parsedVolume))


### PR DESCRIPTION
Old picked up any word with "s" as a volume and only grabbed 1st character in a number. Commit will only grab "s" or "season" at the beginning of the string.

Related to #545 .