### PR TITLE
feat: configure CORS and Swagger

### DIFF
--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -17,7 +17,7 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@v4.1.0
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v4.2.0
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub

--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:      
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU

--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -17,7 +17,7 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@v4.2.0
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -33,7 +33,7 @@ jobs:
       
       # https://github.com/docker/build-push-action#multi-platform-image
       - name: Build and push API
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v7.3.0
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -26,7 +26,7 @@ jobs:
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.5.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -17,7 +17,7 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@v4.1.0
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v4.2.0
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -17,7 +17,7 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@v4.2.0
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -33,7 +33,7 @@ jobs:
       
       # https://github.com/docker/build-push-action#multi-platform-image
       - name: Build and push API
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v7.3.0
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -26,7 +26,7 @@ jobs:
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.5.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -17,7 +17,7 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@v4.1.0
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v4.2.0
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -17,7 +17,7 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@v4.2.0
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -33,7 +33,7 @@ jobs:
       
       # https://github.com/docker/build-push-action#multi-platform-image
       - name: Build and push API
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v7.3.0
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -26,7 +26,7 @@ jobs:
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.5.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '9.x'
 

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -32,16 +32,28 @@ log.Info("Logger Configured.");
 
 log.Info("Starting up");
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+string? allowedCorsOrigin = RuntimeConfiguration.GetAllowedCorsOrigin(builder.Configuration);
+bool swaggerEnabled = RuntimeConfiguration.IsSwaggerEnabled(builder.Configuration);
 
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowAll",
         policy =>
         {
-            policy
-                .AllowAnyOrigin()
-                .AllowAnyMethod()
-                .AllowAnyHeader();
+            if (allowedCorsOrigin is null)
+            {
+                policy
+                    .AllowAnyOrigin()
+                    .AllowAnyMethod()
+                    .AllowAnyHeader();
+            }
+            else
+            {
+                policy
+                    .WithOrigins(allowedCorsOrigin)
+                    .AllowAnyMethod()
+                    .AllowAnyHeader();
+            }
         });
 });
 
@@ -116,8 +128,6 @@ builder.WebHost.UseUrls($"http://*:{TrangaSettings.Port}");
 log.Info("Starting app...");
 WebApplication app = builder.Build();
 
-app.UseCors("AllowAll");
-
 ApiVersionSet apiVersionSet = app.NewApiVersionSet()
     .HasApiVersion(new ApiVersion(2))
     .ReportApiVersions()
@@ -130,16 +140,19 @@ app.MapControllers()
     .WithApiVersionSet(apiVersionSet)
     .MapToApiVersion(2);
 
-log.Debug("Adding Swagger...");
-app.UseSwagger(opts =>
+if (swaggerEnabled)
 {
-    opts.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
-    opts.RouteTemplate = "swagger/{documentName}/swagger.json";
-});
-app.UseSwaggerUI(opts =>
-{
-    opts.SwaggerEndpoint("/swagger/v2/swagger.json", "v2");
-});
+    log.Debug("Adding Swagger...");
+    app.UseSwagger(opts =>
+    {
+        opts.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
+        opts.RouteTemplate = "swagger/{documentName}/swagger.json";
+    });
+    app.UseSwaggerUI(opts =>
+    {
+        opts.SwaggerEndpoint("/swagger/v2/swagger.json", "v2");
+    });
+}
 
 app.UseHttpsRedirection();
 

--- a/API/RuntimeConfiguration.cs
+++ b/API/RuntimeConfiguration.cs
@@ -1,0 +1,28 @@
+namespace API;
+
+public static class RuntimeConfiguration
+{
+    public static string? GetAllowedCorsOrigin(IConfiguration configuration)
+    {
+        string? allowedCorsOrigin = configuration["TRANGA_CORS:ALLOWED_ORIGIN"];
+
+        if (string.IsNullOrWhiteSpace(allowedCorsOrigin))
+        {
+            return null;
+        }
+
+        return allowedCorsOrigin;
+    }
+
+    public static bool IsSwaggerEnabled(IConfiguration configuration)
+    {
+        string? configuredValue = configuration["TRANGA_SWAGGER:ENABLED"];
+
+        if (bool.TryParse(configuredValue, out bool swaggerEnabled))
+        {
+            return swaggerEnabled;
+        }
+
+        return true;
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ Tranga is using a **code-first** EF-Core approach. If you modify the database(co
 | POSTGRES_DB       | `postgres`       |
 | POSTGRES_USER     | `postgres`       |
 | POSTGRES_PASSWORD | `postgres`       |
+| TRANGA_CORS__ALLOWED_ORIGIN | unset (allow any origin) |
+| TRANGA_SWAGGER__ENABLED | `true` |
 
 ### A broad overview of where is what:
 

--- a/Tests/RuntimeConfigurationTests.cs
+++ b/Tests/RuntimeConfigurationTests.cs
@@ -1,0 +1,60 @@
+using API;
+using Microsoft.Extensions.Configuration;
+
+namespace Tests;
+
+public class RuntimeConfigurationTests
+{
+    [Fact]
+    public void GetAllowedCorsOrigin_ReturnsNull_WhenValueIsNotConfigured()
+    {
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>());
+
+        string? allowedCorsOrigin = RuntimeConfiguration.GetAllowedCorsOrigin(configuration);
+
+        Assert.Null(allowedCorsOrigin);
+    }
+
+    [Fact]
+    public void GetAllowedCorsOrigin_ReturnsConfiguredOrigin()
+    {
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            ["TRANGA_CORS:ALLOWED_ORIGIN"] = "https://tranga.example.test"
+        });
+
+        string? allowedCorsOrigin = RuntimeConfiguration.GetAllowedCorsOrigin(configuration);
+
+        Assert.Equal("https://tranga.example.test", allowedCorsOrigin);
+    }
+
+    [Fact]
+    public void IsSwaggerEnabled_ReturnsTrue_WhenValueIsNotConfigured()
+    {
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>());
+
+        bool swaggerEnabled = RuntimeConfiguration.IsSwaggerEnabled(configuration);
+
+        Assert.True(swaggerEnabled);
+    }
+
+    [Fact]
+    public void IsSwaggerEnabled_ReturnsFalse_WhenConfiguredFalse()
+    {
+        IConfiguration configuration = CreateConfiguration(new Dictionary<string, string?>
+        {
+            ["TRANGA_SWAGGER:ENABLED"] = "false"
+        });
+
+        bool swaggerEnabled = RuntimeConfiguration.IsSwaggerEnabled(configuration);
+
+        Assert.False(swaggerEnabled);
+    }
+
+    private static IConfiguration CreateConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}


### PR DESCRIPTION
Adds opt-in runtime configuration for CORS and Swagger without changing existing default behavior.

TRANGA_CORS__ALLOWED_ORIGIN restricts the API to one configured browser origin when set.

TRANGA_SWAGGER__ENABLED=false disables Swagger and its UI.

Unset values preserve existing behavior for backwards compatibility.

Includes focused configuration tests and documents both settings in CONTRIBUTING.md.

No database schema, connector, Docker, or authentication behavior is changed.