### PR TITLE
Align frontend ESLint stylistic rules with Prettier config

### DIFF
--- a/Frontend/.prettierrc
+++ b/Frontend/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "trailingComma": "es5",
+    "trailingComma": "all",
     "tabWidth": 4,
     "singleQuote": true,
     "printWidth": 140,

--- a/Frontend/app/api/tranga/zod.gen.ts
+++ b/Frontend/app/api/tranga/zod.gen.ts
@@ -59,7 +59,7 @@ export const zServicesMangaMangaDownloadLink = z.object({
             .int()
             .check(
                 z.minimum(-2147483648, { error: 'Invalid value: Expected int32 to be >= -2147483648' }),
-                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' })
+                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
             ),
         z.string().check(z.regex(/^-?(?:0|[1-9]\d*)$/)),
     ]),
@@ -87,7 +87,7 @@ export const zServicesMangaPatchMangaDownloadLinkRequest = z.object({
             .int()
             .check(
                 z.minimum(-2147483648, { error: 'Invalid value: Expected int32 to be >= -2147483648' }),
-                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' })
+                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
             ),
         z.string().check(z.regex(/^-?(?:0|[1-9]\d*)$/)),
     ]),
@@ -112,10 +112,10 @@ export const zServicesMangaMetadata = z.object({
                 .int()
                 .check(
                     z.minimum(-2147483648, { error: 'Invalid value: Expected int32 to be >= -2147483648' }),
-                    z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' })
+                    z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
                 ),
             z.string().check(z.regex(/^-?(?:0|[1-9]\d*)$/)),
-        ])
+        ]),
     ),
     language: z.nullish(z.string().check(z.minLength(0), z.maxLength(8))),
     chaptersNumber: z.nullish(
@@ -124,10 +124,10 @@ export const zServicesMangaMetadata = z.object({
                 .int()
                 .check(
                     z.minimum(-2147483648, { error: 'Invalid value: Expected int32 to be >= -2147483648' }),
-                    z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' })
+                    z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
                 ),
             z.string().check(z.regex(/^-?(?:0|[1-9]\d*)$/)),
-        ])
+        ]),
     ),
     coverId: z.nullable(z.uuid()),
     genres: z.optional(z.array(z.string())),
@@ -159,10 +159,10 @@ export const zServicesMangaSearchQuery = z.object({
                 .int()
                 .check(
                     z.minimum(-2147483648, { error: 'Invalid value: Expected int32 to be >= -2147483648' }),
-                    z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' })
+                    z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
                 ),
             z.string().check(z.regex(/^-?(?:0|[1-9]\d*)$/)),
-        ])
+        ]),
     ),
     author: z.nullish(z.string()),
     artist: z.nullish(z.string()),
@@ -173,15 +173,15 @@ export const zServicesMangaSearchQuery = z.object({
                 .bigint()
                 .check(
                     z.minimum(BigInt('-9223372036854775808'), { error: 'Invalid value: Expected int64 to be >= -9223372036854775808' }),
-                    z.maximum(BigInt('9223372036854775807'), { error: 'Invalid value: Expected int64 to be <= 9223372036854775807' })
+                    z.maximum(BigInt('9223372036854775807'), { error: 'Invalid value: Expected int64 to be <= 9223372036854775807' }),
                 ),
             z.coerce
                 .bigint()
                 .check(
                     z.minimum(BigInt('-9223372036854775808'), { error: 'Invalid value: Expected int64 to be >= -9223372036854775808' }),
-                    z.maximum(BigInt('9223372036854775807'), { error: 'Invalid value: Expected int64 to be <= 9223372036854775807' })
+                    z.maximum(BigInt('9223372036854775807'), { error: 'Invalid value: Expected int64 to be <= 9223372036854775807' }),
                 ),
-        ])
+        ]),
     ),
     mangaDexSeriesId: z.nullish(z.uuid()),
 });
@@ -313,7 +313,7 @@ export const zServicesNotificationsPutExtensionRequestGotify = z.object({
             .int()
             .check(
                 z.minimum(-2147483648, { error: 'Invalid value: Expected int32 to be >= -2147483648' }),
-                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' })
+                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
             ),
         z.string().check(z.regex(/^-?(?:0|[1-9]\d*)$/)),
     ]),
@@ -336,7 +336,7 @@ export const zServicesNotificationsPutExtensionRequestNtfySh = z.object({
             .int()
             .check(
                 z.minimum(-2147483648, { error: 'Invalid value: Expected int32 to be >= -2147483648' }),
-                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' })
+                z.maximum(2147483647, { error: 'Invalid value: Expected int32 to be <= 2147483647' }),
             ),
         z.string().check(z.regex(/^-?(?:0|[1-9]\d*)$/)),
     ]),

--- a/Frontend/app/app.vue
+++ b/Frontend/app/app.vue
@@ -31,7 +31,7 @@
                             trailing: 'hidden',
                         }" />
                     <UButton to="/settings" icon="i-lucide-settings" variant="ghost" color="secondary" />
-                    <UButton icon="i-lucide-book-search" @click="searchOverlay.open()">Search <UKbd value="ctrl+s" /></UButton>
+                    <UButton icon="i-lucide-book-search" @click="searchOverlay.open()"> Search <UKbd value="ctrl+s" /> </UButton>
                 </div>
             </template>
         </UHeader>

--- a/Frontend/app/components/Library/ExtensionCard.vue
+++ b/Frontend/app/components/Library/ExtensionCard.vue
@@ -5,7 +5,7 @@
                 <span class="font-medium">{{ library.libraryServiceType }}</span>
                 <span class="text-sm text-muted">{{ library.baseUrl }}</span>
             </div>
-            <UButton label="Delete" color="error" @click="removeLibrary" loading-auto />
+            <UButton label="Delete" color="error" loading-auto @click="removeLibrary" />
         </div>
     </UCard>
 </template>

--- a/Frontend/app/components/Manga/List.vue
+++ b/Frontend/app/components/Manga/List.vue
@@ -1,10 +1,10 @@
 <template>
     <UPageGrid :ui="{ base: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-4' }">
-        <USkeleton v-if="loading" v-for="_ in [...Array(3)]" class="w-60 h-90" />
+        <USkeleton v-for="_ in [...Array(3)]" v-if="loading" class="w-60 h-90" />
 
         <UPageCard
-            v-if="!loading"
             v-for="manga in mangas"
+            v-if="!loading"
             :to="`/manga/${manga.mangaId}`"
             class="relative overflow-clip"
             :ui="{ container: 'p-0 sm:p-0' }"
@@ -16,7 +16,7 @@
             <MangaCover
                 :file-id="manga.metadataEntry?.coverId"
                 :manga-id="manga.mangaId"
-                noBlur
+                no-blur
                 class="z-0"
                 :class="manga.metadataEntry?.nsfw ? 'blur-md' : 'blur-xs'" />
         </UPageCard>

--- a/Frontend/app/components/Manga/Page.vue
+++ b/Frontend/app/components/Manga/Page.vue
@@ -18,16 +18,22 @@
                 :style="{ '--sidebar-width': `${size}px` }">
                 <MangaCover
                     :file-id="manga?.metadataEntry?.coverId"
-                    :mangaId="manga?.mangaId"
-                    :noBlur="!manga?.metadataEntry?.nsfw"
+                    :manga-id="manga?.mangaId"
+                    :no-blur="!manga?.metadataEntry?.nsfw"
                     class="aspect-6/9 w-full max-w-2xs mx-auto md:mx-0" />
 
                 <div class="flex flex-col gap-2">
                     <div class="flex flex-row gap-2 items-baseline flex-wrap">
-                        <p v-if="$props.title" class="text-lg font-semibold">{{ $props.title }}</p>
-                        <p v-else-if="manga?.metadataEntry?.series" class="text-lg font-semibold">{{ manga?.metadataEntry?.series }}</p>
+                        <p v-if="$props.title" class="text-lg font-semibold">
+                            {{ $props.title }}
+                        </p>
+                        <p v-else-if="manga?.metadataEntry?.series" class="text-lg font-semibold">
+                            {{ manga?.metadataEntry?.series }}
+                        </p>
                         <USkeleton v-else class="h-lh w-14" />
-                        <p v-if="manga?.metadataEntry?.year" class="text-dimmed text-sm">{{ manga.metadataEntry?.year }}</p>
+                        <p v-if="manga?.metadataEntry?.year" class="text-dimmed text-sm">
+                            {{ manga.metadataEntry?.year }}
+                        </p>
                     </div>
                     <div class="flex flex-row gap-2 items-center flex-wrap">
                         <UBadge
@@ -84,7 +90,7 @@ const { el, size, isDragging, onMouseDown, onTouchStart, onDoubleClick } = useRe
 
 const navigation = computed((): NavigationMenuProps => {
     const actionItems: NavigationMenuItem[] = (props.actions?.(props.manga) ?? []).map(
-        (action): NavigationMenuItem => ({ label: action.label, icon: action.icon, to: action.to, target: action.target })
+        (action): NavigationMenuItem => ({ label: action.label, icon: action.icon, to: action.to, target: action.target }),
     );
 
     return {

--- a/Frontend/app/components/Metadata/Page.vue
+++ b/Frontend/app/components/Metadata/Page.vue
@@ -5,7 +5,9 @@
                 <div class="flex flex-row gap-2 items-baseline">
                     <p v-if="$props.title">{{ $props.title }}</p>
                     <p v-else-if="metadata?.series">{{ metadata.series }}</p>
-                    <p v-if="metadata?.year" class="text-dimmed text-sm">{{ metadata.year }}</p>
+                    <p v-if="metadata?.year" class="text-dimmed text-sm">
+                        {{ metadata.year }}
+                    </p>
                     <USkeleton v-else class="h-lh w-14" />
                 </div>
                 <div class="flex flex-row gap-4 items-center mt-1">
@@ -47,9 +49,9 @@
             <!-- Passes through the slots -->
             <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
                 <slot v-if="slotName !== 'default'" :name="slotName as unknown" v-bind="slotProps" />
-                <MangaCover v-else :file-id="metadata?.coverId" :noBlur="!metadata?.nsfw" class="aspect-6/9 max-h-sm max-w-sm" />
+                <MangaCover v-else :file-id="metadata?.coverId" :no-blur="!metadata?.nsfw" class="aspect-6/9 max-h-sm max-w-sm" />
             </template>
-            <MangaCover :file-id="metadata?.coverId" :noBlur="!metadata?.nsfw" class="aspect-6/9 max-h-sm max-w-sm" />
+            <MangaCover :file-id="metadata?.coverId" :no-blur="!metadata?.nsfw" class="aspect-6/9 max-h-sm max-w-sm" />
         </UPageCTA>
 
         <UPageSection :ui="{ container: 'sm:py-8 lg:py-8' }">

--- a/Frontend/app/components/Notification/ExtensionCard.vue
+++ b/Frontend/app/components/Notification/ExtensionCard.vue
@@ -1,7 +1,7 @@
 <template>
     <UCard>
         {{ extension }}
-        <UButton label="Delete" color="error" @click="removeExtension" loading-auto />
+        <UButton label="Delete" color="error" loading-auto @click="removeExtension" />
     </UCard>
 </template>
 
@@ -26,7 +26,7 @@ const removeExtension = async () => {
                 refreshNuxtData(ApiKeys.Notifications.Extensions);
                 toast.add({ title: 'Removed extension.', color: 'success' });
             },
-        }
+        },
     );
 };
 </script>

--- a/Frontend/app/components/Search.vue
+++ b/Frontend/app/components/Search.vue
@@ -17,8 +17,8 @@
                         </template>
                     </UInput>
                     <UCheckboxGroup
-                        legend="Search on:"
                         v-model="selectedExtensions"
+                        legend="Search on:"
                         orientation="horizontal"
                         color="secondary"
                         :items="metadataExtensions"
@@ -46,7 +46,7 @@ const toast = useToast();
 const { metadataExtensions } = await useMetadataExtensions();
 
 const selectedExtensions = ref<string[]>(
-    metadataExtensions.value?.map((e: ServicesMangaIMetadataExtension) => e.metadataExtensionId as string) ?? []
+    metadataExtensions.value?.map((e: ServicesMangaIMetadataExtension) => e.metadataExtensionId as string) ?? [],
 );
 const searchQuery = ref<{ title?: string }>({});
 

--- a/Frontend/app/components/Tranga/Chip.vue
+++ b/Frontend/app/components/Tranga/Chip.vue
@@ -3,9 +3,10 @@
         <template #content>
             <UIcon :name="icon" :class="`size-${sizeToNumber * 2}`" />
         </template>
-        <slot></slot>
+        <slot />
     </UChip>
 </template>
+
 <script setup lang="ts">
 import type { ChipProps } from '@nuxt/ui/components/Chip.vue';
 

--- a/Frontend/app/components/Tranga/List.vue
+++ b/Frontend/app/components/Tranga/List.vue
@@ -1,6 +1,6 @@
 <template>
     <UBlogPosts class="mt-4">
-        <USkeleton v-if="loading" v-for="_ in [...Array(3)]" class="w-full h-96" />
+        <USkeleton v-for="_ in [...Array(3)]" v-if="loading" class="w-full h-96" />
         <slot />
     </UBlogPosts>
 </template>

--- a/Frontend/app/components/Tranga/Page.vue
+++ b/Frontend/app/components/Tranga/Page.vue
@@ -9,7 +9,9 @@
                                 v-bind="pageTitle.icon"
                                 class="size-10"
                                 :class="pageTitle.icon.color && `text-${pageTitle.icon.color}`" />
-                            <p class="text-3xl mt-1" :class="collapsed && 'hidden'">{{ pageTitle.title }}</p>
+                            <p class="text-3xl mt-1" :class="collapsed && 'hidden'">
+                                {{ pageTitle.title }}
+                            </p>
                         </div>
                     </slot>
                     <UInput

--- a/Frontend/app/components/Workers/List.vue
+++ b/Frontend/app/components/Workers/List.vue
@@ -65,7 +65,7 @@ const currentTaskChapter = (worker: ServicesTasksWorker) => {
 const statusOrder: Record<ServicesTasksWorker['status'], number> = { Busy: 0, Retiring: 1, Idle: 2 };
 
 const sorted = computed((): ServicesTasksWorker[] =>
-    [...(props.workers ?? [])].sort((w1, w2) => statusOrder[w1.status] - statusOrder[w2.status])
+    [...(props.workers ?? [])].sort((w1, w2) => statusOrder[w1.status] - statusOrder[w2.status]),
 );
 
 const columns: TableColumn<ServicesTasksWorker>[] = [

--- a/Frontend/app/pages/downloads.vue
+++ b/Frontend/app/pages/downloads.vue
@@ -15,7 +15,7 @@ import type { GetTasksMangaDownloadsResponse, GetMangasChaptersResponse } from '
 const includeFinished = useState<boolean>(() => false);
 const { data, refresh, status } = await useTranga<GetTasksMangaDownloadsResponse>(
     () => `/tasks/manga/downloads?includeFinished=${includeFinished.value}`,
-    { lazy: true, watch: [includeFinished] }
+    { lazy: true, watch: [includeFinished] },
 );
 
 defineShortcuts({ meta_r: () => refresh() });

--- a/Frontend/app/pages/index.vue
+++ b/Frontend/app/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-    <TrangaPage v-model:search="search" :page-title="{ title: 'Manga List', icon: { name: 'i-lucide-book' } }" searchEnabled>
+    <TrangaPage v-model:search="search" :page-title="{ title: 'Manga List', icon: { name: 'i-lucide-book' } }" search-enabled>
         <UContainer>
             <MangaList :mangas="mangaList" :loading="status !== 'success'" />
         </UContainer>
@@ -18,7 +18,7 @@ const { data, status, refresh } = await useTranga<GetMangasResponse>('/mangas', 
 const mangaList = computed(() =>
     search.value
         ? data.value?.filter((m) => m.metadataEntry?.series.toLocaleLowerCase().includes(search.value!.toLocaleLowerCase()))
-        : data.value
+        : data.value,
 );
 
 defineShortcuts({ shift_r: () => refresh() });

--- a/Frontend/app/pages/manga/[mangaId]/downloadLinks.vue
+++ b/Frontend/app/pages/manga/[mangaId]/downloadLinks.vue
@@ -14,7 +14,7 @@ const mangaId = useRoute().params.mangaId as string;
 
 const { data: downloadLinks, status: statusDownloadLinks } = useTranga<PostMangasSearchByMangaIdDownloadLinksResponse>(
     () => `/mangas/search/${mangaId}/downloadLinks`,
-    { method: 'POST' }
+    { method: 'POST' },
 );
 
 const navigation = computed((): NavigationMenuProps => {

--- a/Frontend/app/pages/manga/[mangaId]/downloads.vue
+++ b/Frontend/app/pages/manga/[mangaId]/downloads.vue
@@ -21,7 +21,7 @@ const mangaId = useRoute().params.mangaId as string;
 const includeFinished = useState<boolean>(() => false);
 const { data, refresh } = await useTranga<GetTasksMangaByMangaIdDownloadsResponse>(
     () => `/tasks/manga/${mangaId}/downloads?includeFinished=${includeFinished.value}`,
-    { lazy: true, watch: [includeFinished] }
+    { lazy: true, watch: [includeFinished] },
 );
 
 defineShortcuts({ meta_r: () => refresh() });

--- a/Frontend/app/pages/manga/[mangaId]/index.vue
+++ b/Frontend/app/pages/manga/[mangaId]/index.vue
@@ -22,7 +22,7 @@ const { data: manga, status: statusManga } = await useTranga<GetMangasByMangaIdR
 
 const { data: downloadLinks, status: statusDownloadLinks } = useTranga<GetMangasByMangaIdDownloadLinksResponse>(
     () => `/mangas/${mangaId}/downloadLinks`,
-    { key: ApiKeys.Manga.DownloadLinks(mangaId) }
+    { key: ApiKeys.Manga.DownloadLinks(mangaId) },
 );
 
 const { data: libraryMappings } = useTranga<GetLibrariesMappingsByMangaIdResponse>(() => `/libraries/mappings/${mangaId}`, {
@@ -38,7 +38,7 @@ const actions = (manga?: ServicesMangaManga): ButtonProps[] | undefined => [
             icon: 'i-lucide-external-link',
             variant: 'outline',
             target: '_blank',
-        })
+        }),
     ),
 ];
 </script>

--- a/Frontend/app/pages/manga/[mangaId]/metadataEntries.vue
+++ b/Frontend/app/pages/manga/[mangaId]/metadataEntries.vue
@@ -15,7 +15,7 @@ const mangaId = useRoute().params.mangaId as string;
 
 const { data: metadataSources, status: statusMetadata } = await useTranga<GetMangasByMangaIdMetadataRelatedResponse>(
     () => `/mangas/${mangaId}/metadata/related`,
-    { key: ApiKeys.Manga.Metadata.RelatedManga(mangaId) }
+    { key: ApiKeys.Manga.Metadata.RelatedManga(mangaId) },
 );
 
 const navigation = computed((): NavigationMenuProps => {

--- a/Frontend/app/pages/metadata/[metadataId].vue
+++ b/Frontend/app/pages/metadata/[metadataId].vue
@@ -1,5 +1,5 @@
 <template>
-    <MetadataPage :metadata="metadata" :actions="actions" :loading="statusMetadata !== 'success'"> </MetadataPage>
+    <MetadataPage :metadata="metadata" :actions="actions" :loading="statusMetadata !== 'success'" />
 </template>
 
 <script setup lang="ts">
@@ -19,7 +19,7 @@ const mangaId = useRoute().query.mangaId as string | undefined;
 
 const { data: metadata, status: statusMetadata } = await useTranga<GetMangasMetadataByMetadataIdResponse>(
     () => `/mangas/metadata/${metadataId}`,
-    { key: Manga.Metadata.Entry(metadataId) }
+    { key: Manga.Metadata.Entry(metadataId) },
 );
 
 const { data: manga } = await useTranga<GetMangasMetadataByMetadataIdMangaResponse>(() => `/mangas/metadata/${metadataId}/manga`, {
@@ -28,7 +28,7 @@ const { data: manga } = await useTranga<GetMangasMetadataByMetadataIdMangaRespon
 
 const { data: relatedMangaIds } = await useTranga<GetMangasMetadataByMetadataIdMangaRelatedResponse>(
     () => `/mangas/metadata/${metadataId}/manga/related`,
-    { key: Manga.Metadata.RelatedManga(metadataId) }
+    { key: Manga.Metadata.RelatedManga(metadataId) },
 );
 
 const actions = (m?: ServicesMangaMetadata): ButtonProps[] | undefined => {

--- a/Frontend/app/pages/metadata/index.vue
+++ b/Frontend/app/pages/metadata/index.vue
@@ -2,12 +2,13 @@
     <TrangaPage
         v-model:search="search"
         :page-title="{ title: 'Metadata List', icon: { name: 'i-lucide-info', color: 'info' } }"
-        searchEnabled>
+        search-enabled>
         <UPageSection :ui="{ container: 'sm:py-0 lg:py-0 gap-8 sm:gap-8' }">
             <MetadataList :metadata-list="metadataList" :loading="status !== 'success'" />
         </UPageSection>
     </TrangaPage>
 </template>
+
 <script setup lang="ts">
 import type { GetMangasMetadataResponse } from '~/api/tranga';
 import { ApiKeys } from '~/composables/ApiKeys';
@@ -17,6 +18,6 @@ const search = ref<string>();
 const { data, status } = useTranga<GetMangasMetadataResponse>('/mangas/metadata', { key: ApiKeys.MetadataExtensions });
 
 const metadataList = computed(() =>
-    search.value ? data.value?.filter((m) => m.series.toLocaleLowerCase().includes(search.value!.toLocaleLowerCase())) : data.value
+    search.value ? data.value?.filter((m) => m.series.toLocaleLowerCase().includes(search.value!.toLocaleLowerCase())) : data.value,
 );
 </script>

--- a/Frontend/app/pages/settings/index.vue
+++ b/Frontend/app/pages/settings/index.vue
@@ -6,4 +6,5 @@
         </UPageList>
     </TrangaPage>
 </template>
+
 <script setup lang="ts"></script>

--- a/Frontend/app/pages/settings/libraries.vue
+++ b/Frontend/app/pages/settings/libraries.vue
@@ -7,8 +7,8 @@
                     color="neutral"
                     variant="subtle"
                     trailing-icon="i-lucide-chevron-down"
-                    @click="open = !open"
-                    block />
+                    block
+                    @click="open = !open" />
 
                 <template #content>
                     <UCard class="m-0.5 mt-2">
@@ -50,11 +50,13 @@
                                     label="Test Connection"
                                     color="neutral"
                                     variant="soft"
-                                    @click="testConnection"
                                     loading-auto
-                                    icon="i-lucide-plug" />
+                                    icon="i-lucide-plug"
+                                    @click="testConnection" />
                                 <UButton
                                     label="Cancel"
+                                    color="secondary"
+                                    variant="soft"
                                     @click="
                                         () => {
                                             state = {};
@@ -62,10 +64,8 @@
                                             connectionVerified = false;
                                             open = false;
                                         }
-                                    "
-                                    color="secondary"
-                                    variant="soft" />
-                                <UButton label="Add" @click="createLibrary" loading-auto icon="i-lucide-plus" />
+                                    " />
+                                <UButton label="Add" loading-auto icon="i-lucide-plus" @click="createLibrary" />
                             </div>
                         </div>
                     </UCard>
@@ -102,7 +102,7 @@ watch(
     () => {
         connectionVerified.value = false;
     },
-    { deep: true }
+    { deep: true },
 );
 
 const testConnection = async () => {

--- a/Frontend/app/pages/settings/notifications.vue
+++ b/Frontend/app/pages/settings/notifications.vue
@@ -7,8 +7,8 @@
                     color="neutral"
                     variant="subtle"
                     trailing-icon="i-lucide-chevron-down"
-                    @click="open = !open"
-                    block />
+                    block
+                    @click="open = !open" />
 
                 <template #content>
                     <UCard class="m-0.5 mt-2">
@@ -32,7 +32,7 @@
                                         </UFormField>
                                         <div class="flex flex-row gap-2">
                                             <UFormField label="Host" name="host" class="grow">
-                                                <UInput v-model="state.host" class="w-full" @update:modelValue="autoPort" />
+                                                <UInput v-model="state.host" class="w-full" @update:model-value="autoPort" />
                                             </UFormField>
                                             <UFormField label="Port" name="port">
                                                 <UInput v-model="state.port" class="w-full" type="number" />
@@ -65,7 +65,7 @@
                                         </UFormField>
                                         <div class="flex flex-row gap-2">
                                             <UFormField label="Host" name="host" class="grow">
-                                                <UInput v-model="state.host" class="w-full" @update:modelValue="autoPort" />
+                                                <UInput v-model="state.host" class="w-full" @update:model-value="autoPort" />
                                             </UFormField>
                                             <UFormField label="Port" name="port">
                                                 <UInput v-model="state.port" class="w-full" type="number" />
@@ -102,15 +102,15 @@
                             <div class="flex flex-row gap-4 justify-end">
                                 <UButton
                                     label="Cancel"
+                                    color="secondary"
+                                    variant="soft"
                                     @click="
                                         () => {
                                             state = {};
                                             open = false;
                                         }
-                                    "
-                                    color="secondary"
-                                    variant="soft" />
-                                <UButton label="Add" @click="createExtension" loading-auto icon="i-lucide-plus" />
+                                    " />
+                                <UButton label="Add" loading-auto icon="i-lucide-plus" @click="createExtension" />
                             </div>
                         </div>
                     </UCard>

--- a/Frontend/app/pages/tasks.vue
+++ b/Frontend/app/pages/tasks.vue
@@ -138,7 +138,7 @@ const { data: mangas, status: mangaStatus } = await useTranga<GetMangasResponse>
 const mangaOptions = computed(() =>
     (mangas.value ?? [])
         .map((m) => ({ label: m.metadataEntry?.series ?? m.mangaId, value: m.mangaId }))
-        .sort((a, b) => a.label.localeCompare(b.label))
+        .sort((a, b) => a.label.localeCompare(b.label)),
 );
 
 const listRef = useTemplateRef('listRef');
@@ -148,7 +148,7 @@ onMounted(() => {
         () => {
             skip.value += LIMIT;
         },
-        { distance: 200, canLoadMore: () => status.value !== 'pending' && hasMore.value }
+        { distance: 200, canLoadMore: () => status.value !== 'pending' && hasMore.value },
     );
 });
 

--- a/Frontend/eslint.config.mjs
+++ b/Frontend/eslint.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
 import withNuxt from './.nuxt/eslint.config.mjs';
+import prettierConfig from '@vue/eslint-config-prettier';
 
-export default withNuxt();
-// Your custom configs here
+export default withNuxt(prettierConfig);

--- a/Frontend/nuxt.config.ts
+++ b/Frontend/nuxt.config.ts
@@ -4,15 +4,15 @@ export default defineNuxtConfig({
 
     devtools: { enabled: true },
 
-    css: ['~/assets/css/main.css'],
-
-    compatibilityDate: '2025-01-15',
-
-    eslint: { config: { stylistic: { commaDangle: 'never', braceStyle: '1tbs', indent: 4 } } },
-
     app: { head: { title: 'Tranga', htmlAttrs: { lang: 'en' }, link: [{ rel: 'icon', type: 'image/png', href: '/blahaj.png' }] } },
+
+    css: ['~/assets/css/main.css'],
 
     runtimeConfig: { public: { api: { baseUrl: 'localhost:5000' } } },
 
+    compatibilityDate: '2025-01-15',
+
     vite: { server: { allowedHosts: ['host.docker.internal'] } },
+
+    eslint: { config: { stylistic: { semi: true, arrowParens: true, braceStyle: '1tbs', indent: 4, commaDangle: 'always-multiline' } } },
 });

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -18,6 +18,7 @@
             "devDependencies": {
                 "@hey-api/openapi-ts": "0.94.5",
                 "@nuxt/eslint": "^1.15.2",
+                "@vue/eslint-config-prettier": "^10.2.0",
                 "eslint": "^10.0.3",
                 "prettier": "^3.8.1",
                 "typescript": "^5.9.3",
@@ -3833,6 +3834,19 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@pkgr/core": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+            "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/pkgr"
+            }
+        },
         "node_modules/@polka/url": {
             "version": "1.0.0-next.29",
             "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -6365,6 +6379,21 @@
             "integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
             "license": "MIT"
         },
+        "node_modules/@vue/eslint-config-prettier": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-10.2.0.tgz",
+            "integrity": "sha512-GL3YBLwv/+b86yHcNNfPJxOTtVFJ4Mbc9UU3zR+KVoG7SwGTjPT+32fXamscNumElhcpXW3mT0DgzS9w32S7Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-config-prettier": "^10.0.1",
+                "eslint-plugin-prettier": "^5.2.2"
+            },
+            "peerDependencies": {
+                "eslint": ">= 8.21.0",
+                "prettier": ">= 3.0.0"
+            }
+        },
         "node_modules/@vue/language-core": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.6.tgz",
@@ -8380,6 +8409,22 @@
                 "eslint": "^9.5.0 || ^10.0.0"
             }
         },
+        "node_modules/eslint-config-prettier": {
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
         "node_modules/eslint-flat-config-utils": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/eslint-flat-config-utils/-/eslint-flat-config-utils-3.0.2.tgz",
@@ -8551,6 +8596,37 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-plugin-prettier": {
+            "version": "5.5.6",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+            "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prettier-linter-helpers": "^1.0.1",
+                "synckit": "^0.11.13"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-prettier"
+            },
+            "peerDependencies": {
+                "@types/eslint": ">=8.0.0",
+                "eslint": ">=8.0.0",
+                "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+                "prettier": ">=3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/eslint": {
+                    "optional": true
+                },
+                "eslint-config-prettier": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-plugin-regexp": {
@@ -8976,6 +9052,13 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
+        },
+        "node_modules/fast-diff": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/fast-fifo": {
             "version": "1.3.2",
@@ -12909,6 +12992,19 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/prettier-linter-helpers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+            "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-diff": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/pretty-bytes": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
@@ -14139,6 +14235,22 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/svgo"
+            }
+        },
+        "node_modules/synckit": {
+            "version": "0.11.13",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+            "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pkgr/core": "^0.3.6"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/synckit"
             }
         },
         "node_modules/tagged-tag": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -24,6 +24,7 @@
     "devDependencies": {
         "@hey-api/openapi-ts": "0.94.5",
         "@nuxt/eslint": "^1.15.2",
+        "@vue/eslint-config-prettier": "^10.2.0",
         "eslint": "^10.0.3",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3",


### PR DESCRIPTION
Nuxt's @nuxt/eslint stylistic layer disagreed with Prettier on semicolons, trailing commas, arrow-fn parens, and Vue/TS line-wrapping, so a bare `prettier --write` produced hundreds of ESLint errors. Match ESLint's stylistic options to the existing Prettier config and pull in @vue/eslint-config-prettier to disable the remaining formatting rules that have no Prettier equivalent (operator-linebreak, attribute wrapping, etc). Regenerated the OpenAPI client so its postProcess step picks up the aligned formatting.