### PR TITLE
Rework mounting

### DIFF
--- a/EnvVars.md
+++ b/EnvVars.md
@@ -4,8 +4,7 @@
 |------------------|------------|----------------------------------------------------------------------------------------------------------------------------------|
 | AllowNSFW        | `false`    | Allow NSFW content in search results                                                                                             |
 | DownloadLanguage | `"en"`     | Language for downloaded chapters                                                                                                 | 
-| MangaDirectory   | `"Manga"`  | Path to directory to save Manga to                                                                                               | 
-| CoverDirectory   | `"Covers"` | Path to temp-directory to save Covers to                                                                                         |
+| MangaDirectory   | `"Manga"`  | Host path to bind-mount for downloaded Manga (docker-compose only; Covers are stored in a managed Docker volume)                | 
 | FLARESOLVERR_URL | null       | When set, a [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) instance will handler requests that Cloudflare rejected |
 
 ## Debug

--- a/Tranga.AppHost/AppHost.cs
+++ b/Tranga.AppHost/AppHost.cs
@@ -72,7 +72,7 @@ IResourceBuilder<ProjectResource> tasksService = builder.AddProject<Services_Tas
         service.Volumes.Add(new Volume()
         {
             Name = "Mangas",
-            Source = EnvVars.MangaDirectory,
+            Source = "${MangaDirectory}",
             Target = "/app/Mangas",
             Type = "bind"
         });
@@ -110,7 +110,7 @@ IResourceBuilder<ProjectResource> mangaService = builder.AddProject<Services_Man
         service.Volumes.Add(new Volume()
         {
             Name = "Covers",
-            Source = EnvVars.CoverDirectory,
+            Source = "${CoverDirectory}",
             Target = "/app/Covers",
             Type = "bind"
         });

--- a/Tranga.AppHost/AppHost.cs
+++ b/Tranga.AppHost/AppHost.cs
@@ -22,6 +22,10 @@ builder.AddDockerComposeEnvironment("env")
             Name = "tranga",
             Driver = "bridge"
         });
+        conf.AddVolume(new Volume()
+        {
+            Name = "Covers"
+        });
     });
 
 IResourceBuilder<ParameterResource> postgresUser = builder.AddParameter("PostgresUser");
@@ -110,9 +114,9 @@ IResourceBuilder<ProjectResource> mangaService = builder.AddProject<Services_Man
         service.Volumes.Add(new Volume()
         {
             Name = "Covers",
-            Source = "${CoverDirectory}",
+            Source = "Covers",
             Target = "/app/Covers",
-            Type = "bind"
+            Type = "volume"
         });
         service.DependsOn = new()
         {

--- a/Tranga.AppHost/EnvVars.cs
+++ b/Tranga.AppHost/EnvVars.cs
@@ -5,6 +5,4 @@ public struct EnvVars
 {
     public static readonly string DBName = Environment.GetEnvironmentVariable("DBName") ?? "tranga";
     public static readonly string POSTGRES_HOST = Environment.GetEnvironmentVariable("POSTGRES_HOST") ?? "tranga-pg";
-    public static readonly string MangaDirectory = Environment.GetEnvironmentVariable("MangaDirectory") ?? "Mangas";
-    public static readonly string CoverDirectory = Environment.GetEnvironmentVariable("CoverDirectory") ?? "Covers";
 }

--- a/Tranga.AppHost/aspire-output/.env
+++ b/Tranga.AppHost/aspire-output/.env
@@ -1,5 +1,3 @@
-CoverDirectory="Covers"
-
 # Container image name for frontend
 FRONTEND_IMAGE=
 

--- a/Tranga.AppHost/aspire-output/docker-compose.yaml
+++ b/Tranga.AppHost/aspire-output/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
     volumes:
       - type: "bind"
         target: "/app/Mangas"
-        source: "Mangas"
+        source: "${MangaDirectory}"
     depends_on:
       tranga-pg:
         condition: "service_started"
@@ -96,7 +96,7 @@ services:
     volumes:
       - type: "bind"
         target: "/app/Covers"
-        source: "Covers"
+        source: "${CoverDirectory}"
     depends_on:
       tranga-pg:
         condition: "service_started"

--- a/Tranga.AppHost/aspire-output/docker-compose.yaml
+++ b/Tranga.AppHost/aspire-output/docker-compose.yaml
@@ -94,9 +94,9 @@ services:
     expose:
       - "${SERVICES_MANGA_PORT}"
     volumes:
-      - type: "bind"
+      - type: "volume"
         target: "/app/Covers"
-        source: "${CoverDirectory}"
+        source: "Covers"
     depends_on:
       tranga-pg:
         condition: "service_started"
@@ -260,3 +260,5 @@ networks:
     driver: "bridge"
   tranga:
     driver: "bridge"
+volumes:
+  Covers: {}


### PR DESCRIPTION
Previously, Volume.Source for both mounts was set from EnvVars.MangaDirectory/CoverDirectory, a plain Environment.GetEnvironmentVariable read evaluated at aspire publish time. That resolved value got baked as a literal string into docker-compose.yaml, so editing 
  .env afterwards had no effect on the running container's bind mount — confirmed this drift already existed in the repo (.env said MangaDirectory="Manga" while the committed docker-compose.yaml had source: "Mangas").                                                
                                                                                                                                                                                                                                                                         
  - Mangas: Volume.Source is now the literal "${MangaDirectory}", so Docker Compose itself substitutes it from .env at runtime.                                                                                                                                          
  - Covers: reverted to a top-level named volume (ConfigureComposeFile → AddVolume), type: volume, with no host path or env var involved — Docker manages its storage as before.                                                                                         
  - Removed the now-dead CoverDirectory/MangaDirectory fields from Tranga.AppHost/EnvVars.cs and the stale CoverDirectory entry from .env/EnvVars.md.                                                                                                                    
  - Regenerated docker-compose.yaml via aspire publish (not hand-edited).                                                                                                                                                                                                
                                                                                                                                                                                                                                                                         
  Test plan                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                         
  - [x] dotnet build Tranga.AppHost/Tranga.AppHost.csproj succeeds                                                                                                                                                                                                       
  - [x] aspire publish --apphost Tranga.AppHost/Tranga.AppHost.csproj regenerates docker-compose.yaml cleanly                                                                                                                                                            
  - [x] docker compose -f Tranga.AppHost/aspire-output/docker-compose.yaml --env-file Tranga.AppHost/aspire-output/.env config shows:                                                                                                                                    
    - Mangas bind source resolves from .env's MangaDirectory (verified changing the value in .env changes the resolved path)                                                                                                                                             
    - Covers resolves to a managed volume (aspire-output_Covers), untouched by env vars                                          