### PR TITLE
Fix gateway api baseurl

### DIFF
--- a/Frontend/app/plugins/apiBaseUrl.ts
+++ b/Frontend/app/plugins/apiBaseUrl.ts
@@ -1,7 +1,8 @@
 export default defineNuxtPlugin({
     name: 'apiBaseUrl',
     async setup(nuxtApp) {
-        const apiBaseUrl = `http://${nuxtApp.$config.public.api.baseUrl}/api`;
+        const configuredBaseUrl = nuxtApp.$config.public.api.baseUrl;
+        const apiBaseUrl = configuredBaseUrl ? `http://${configuredBaseUrl}/api` : '/api';
         return { provide: { apiBaseUrl } };
     },
 });

--- a/Frontend/nuxt.config.ts
+++ b/Frontend/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
 
     app: { head: { title: 'Tranga', htmlAttrs: { lang: 'en' }, link: [{ rel: 'icon', type: 'image/png', href: '/blahaj.png' }] } },
 
-    runtimeConfig: { public: { api: { baseUrl: 'localhost:5000' } } },
+    runtimeConfig: { public: { api: { baseUrl: '' } } },
 
     vite: { server: { allowedHosts: ['host.docker.internal'] } },
 });

--- a/Frontend/nuxt.config.ts
+++ b/Frontend/nuxt.config.ts
@@ -14,5 +14,5 @@ export default defineNuxtConfig({
 
     runtimeConfig: { public: { api: { baseUrl: '' } } },
 
-    vite: { server: { allowedHosts: ['host.docker.internal'] } },
+    vite: { server: { allowedHosts: ['host.docker.internal', 'aspire.dev.internal'] } },
 });

--- a/Tranga.AppHost/AppHost.cs
+++ b/Tranga.AppHost/AppHost.cs
@@ -186,10 +186,6 @@ IResourceBuilder<ProjectResource> librariesService = builder.AddProject<Services
     .WithDockerfileBaseImage("mcr.microsoft.com/dotnet/sdk:10.0", "mcr.microsoft.com/dotnet/aspnet:10.0");
 
 IResourceBuilder<JavaScriptAppResource> frontend = builder.AddJavaScriptApp("frontend", "../Frontend")
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["NUXT_PUBLIC_API_BASE_URL"] = $"localhost:{port}";
-    })
     .WithHttpEndpoint(port: 3000, env: "PORT")
     .WithReference(mangaService)
     .WithReference(tasksService)

--- a/Tranga.AppHost/aspire-output/docker-compose.yaml
+++ b/Tranga.AppHost/aspire-output/docker-compose.yaml
@@ -187,7 +187,6 @@ services:
     image: "ghcr.io/c9glax/tranga-frontend:external-connectors"
     environment:
       NODE_ENV: "production"
-      NUXT_PUBLIC_API_BASE_URL: "localhost:5000"
       PORT: "3000"
       SERVICES_MANGA_HTTP: "http://services-manga:${SERVICES_MANGA_PORT}"
       services__services-manga__http__0: "http://services-manga:${SERVICES_MANGA_PORT}"


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                         
  - The frontend built an absolute API base URL (http://localhost:5000/api) for every API/image request, baked in at container start via NUXT_PUBLIC_API_BASE_URL. This only worked when the browser and the docker host were the same machine — deploying docker compose
  on a remote host broke all API calls and cover images, since the browser tried to reach its own localhost:5000 instead of the server.                                                                                                                                  
  - The YARP gateway already proxies both the frontend and /api/** from the same origin in every environment (Aspire dev and docker-compose), so the frontend never needs to know an absolute host — it can just call /api relative to whatever origin the page was      
  loaded from.                                                                                                                                                                                                                                                           
  - Also fixes a related local Aspire dev-mode issue: Vite's allowedHosts was rejecting the aspire.dev.internal hostname Aspire proxies the frontend through, blocking the gateway-fronted page entirely.                                                                
                                                                                                                                                                                                                                                                         
  Changes                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                         
  - Frontend/app/plugins/apiBaseUrl.ts — falls back to relative /api when no explicit base URL is configured; keeps the absolute-URL branch for standalone npm run dev use against an explicit host.                                                                     
  - Frontend/nuxt.config.ts — default runtimeConfig.public.api.baseUrl changed from 'localhost:5000' to ''; added aspire.dev.internal to Vite's allowedHosts.                                                                                                            
  - Tranga.AppHost/AppHost.cs — removed the NUXT_PUBLIC_API_BASE_URL=localhost:{port} env override on the frontend resource (no longer needed now that relative URLs work through the gateway in both Aspire dev and compose).                                           
  - Tranga.AppHost/aspire-output/docker-compose.yaml (→ docker-compose.yaml symlink) — regenerated via aspire publish, dropping the NUXT_PUBLIC_API_BASE_URL line from the frontend service.                                                                             
                                                                                                                                                                                                                                                                         
  Test plan                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                         
  - [x] npm run typecheck passes                                                                                                                                                                                                                                         
  - [x] dotnet build Tranga.AppHost succeeds (pre-existing nullable warnings only)                                                                                                                                                                                       
  - [x] Confirmed npm run lint failures are pre-existing repo-wide (identical count with/without this change) — not introduced by this PR                                                                                                                                
  - [x] aspire publish regenerated compose diff limited to dropping NUXT_PUBLIC_API_BASE_URL                                                                                                                                                                             
  - [ ] docker compose up on a non-localhost host — confirm API calls and cover images resolve against the page's own origin, not localhost:5000                                                                                                                         
  - [ ] dotnet run --project Tranga.AppHost/Tranga.AppHost.csproj (Aspire dev) — confirm frontend loads via gateway and API calls succeed                                                                                                                                
     