### PR TITLE
Fix regression: restore relative /api baseUrl for gateway proxying

### DIFF
--- a/Frontend/nuxt.config.ts
+++ b/Frontend/nuxt.config.ts
@@ -8,7 +8,7 @@ export default defineNuxtConfig({
 
     css: ['~/assets/css/main.css'],
 
-    runtimeConfig: { public: { api: { baseUrl: 'localhost:5000' } } },
+    runtimeConfig: { public: { api: { baseUrl: '' } } },
 
     compatibilityDate: '2025-01-15',
 


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                              
- NS_ERROR_CONNECTION_REFUSED on non-frontend gateway requests in Docker was caused by Frontend/nuxt.config.ts's runtimeConfig.public.api.baseUrl being hardcoded back to localhost:5000.                                                                            
 - That value was correctly fixed to '' (relative /api, proxied by the gateway) in #597 (commit 31b5e09c), but a later commit on the same PR (3a102dd5, an ESLint stylistic reformat) was based on the pre-fix file and silently reverted it when reformatting        
nuxt.config.ts.                                                                                                                                                                                                                                                      
- The apiBaseUrl.ts plugin's fallback logic was untouched and still correct — only the config default regressed.                                                                                                                                                     
                                                                                                                                                                                                                                                                     
Test plan                                                                                                                                                                                                                                                            
 - [ ] Rebuild/run the Docker Compose stack and confirm API/image requests through the gateway (e.g. cover images, manga list) succeed from a browser that isn't on the same host as the Docker daemon.