### PR TITLE
Fix docker-compose startup race with RabbitMQ not being ready

### DIFF
--- a/Tranga.AppHost/AppHost.cs
+++ b/Tranga.AppHost/AppHost.cs
@@ -49,6 +49,14 @@ IResourceBuilder<RabbitMQServerResource> rabbitmq = builder.AddRabbitMQ("messagi
     {
         service.Name = "messaging";
         service.Networks = ["tranga"];
+        service.Healthcheck = new Healthcheck
+        {
+            Test = ["CMD", "rabbitmq-diagnostics", "-q", "check_port_connectivity"],
+            Interval = "5s",
+            Timeout = "5s",
+            Retries = 12,
+            StartPeriod = "10s"
+        };
     });
 
 IResourceBuilder<ProjectResource> tasksService = builder.AddProject<Services_Tasks>("services-tasks")
@@ -83,7 +91,7 @@ IResourceBuilder<ProjectResource> tasksService = builder.AddProject<Services_Tas
         service.DependsOn = new()
         {
             { "tranga-pg", new ServiceDependency(){ Condition = "service_started" } },
-            { "messaging", new ServiceDependency(){ Condition = "service_started" } }
+            { "messaging", new ServiceDependency(){ Condition = "service_healthy" } }
         };
         service.Restart = "on-failure:3";
     })
@@ -121,7 +129,7 @@ IResourceBuilder<ProjectResource> mangaService = builder.AddProject<Services_Man
         service.DependsOn = new()
         {
             { "tranga-pg", new ServiceDependency(){ Condition = "service_started" } },
-            { "messaging", new ServiceDependency(){ Condition = "service_started" } }
+            { "messaging", new ServiceDependency(){ Condition = "service_healthy" } }
         };
         service.Restart = "on-failure:3";
     })
@@ -152,7 +160,7 @@ IResourceBuilder<ProjectResource> notificationsService = builder.AddProject<Serv
         service.DependsOn = new()
         {
             { "tranga-pg", new ServiceDependency(){ Condition = "service_started" } },
-            { "messaging", new ServiceDependency(){ Condition = "service_started" } }
+            { "messaging", new ServiceDependency(){ Condition = "service_healthy" } }
         };
         service.Restart = "on-failure:3";
     })
@@ -183,7 +191,7 @@ IResourceBuilder<ProjectResource> librariesService = builder.AddProject<Services
         service.DependsOn = new()
         {
             { "tranga-pg", new ServiceDependency(){ Condition = "service_started" } },
-            { "messaging", new ServiceDependency(){ Condition = "service_started" } }
+            { "messaging", new ServiceDependency(){ Condition = "service_healthy" } }
         };
         service.Restart = "on-failure:3";
     })

--- a/Tranga.AppHost/aspire-output/docker-compose.yaml
+++ b/Tranga.AppHost/aspire-output/docker-compose.yaml
@@ -19,6 +19,16 @@ services:
       - "5672"
     networks:
       - "tranga"
+    healthcheck:
+      test:
+        - "CMD"
+        - "rabbitmq-diagnostics"
+        - "-q"
+        - "check_port_connectivity"
+      interval: "5s"
+      timeout: "5s"
+      retries: 12
+      start_period: "10s"
   services-tasks:
     image: "ghcr.io/c9glax/tranga-services_tasks:external-connectors"
     environment:
@@ -58,7 +68,7 @@ services:
       tranga-pg:
         condition: "service_started"
       messaging:
-        condition: "service_started"
+        condition: "service_healthy"
     networks:
       - "tranga"
     restart: "on-failure:3"
@@ -101,7 +111,7 @@ services:
       tranga-pg:
         condition: "service_started"
       messaging:
-        condition: "service_started"
+        condition: "service_healthy"
     networks:
       - "tranga"
     restart: "on-failure:3"
@@ -140,7 +150,7 @@ services:
       tranga-pg:
         condition: "service_started"
       messaging:
-        condition: "service_started"
+        condition: "service_healthy"
     networks:
       - "tranga"
     restart: "on-failure:3"
@@ -179,7 +189,7 @@ services:
       tranga-pg:
         condition: "service_started"
       messaging:
-        condition: "service_started"
+        condition: "service_healthy"
     networks:
       - "tranga"
     restart: "on-failure:3"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                            
   - `docker compose up` could fail because dependent services (`services-tasks`, `services-manga`, `services-notifications`, `services-libraries`) only waited for the RabbitMQ container process to start (`condition: service_started`), not for RabbitMQ to          
   actually be ready to accept AMQP connections.                                                                                                                                                                                                                         
   - Added a `rabbitmq-diagnostics check_port_connectivity` healthcheck to the `messaging` service in `Tranga.AppHost/AppHost.cs`.                                                                                                                                       
   - Switched all four dependent services' `depends_on` condition on `messaging` from `service_started` to `service_healthy`.                                                                                                                                            
   - Regenerated `Tranga.AppHost/aspire-output/docker-compose.yaml` (via `aspire publish`) to match.                                                                                                                                                                     
                                                                                                                                                                                                                                                                         
   ## Test plan                                                                                                                                                                                                                                                          
   - [x] `dotnet build Tranga.AppHost/Tranga.AppHost.csproj` succeeds                                                                                                                                                                                                    
   - [x] `aspire publish` regenerates the compose file with the healthcheck and `service_healthy` conditions                                                                                                                                                             
   - [x] `docker compose config -q` validates the generated file                                                                                                                                                                                                         
   - [x] Brought up just the `messaging` service via `docker compose up -d messaging` and confirmed `docker inspect` shows health transitioning `starting` → `healthy` once RabbitMQ is actually accepting connections