### PR TITLE
Fix cover save failing with UnauthorizedAccessException on named Cove…

### DIFF
--- a/Services.Manga/Dockerfile
+++ b/Services.Manga/Dockerfile
@@ -1,6 +1,7 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
-USER $APP_UID
 WORKDIR /app
+RUN mkdir -p /app/Covers && chown $APP_UID /app/Covers
+USER $APP_UID
 EXPOSE 8080
 EXPOSE 8081
 


### PR DESCRIPTION
…rs volume

Docker creates fresh named volumes owned by root, but the container runs as non-root $APP_UID, so writes into /app/Covers failed with Permission denied. Pre-create and chown the mount point in the image so the volume inherits the correct owner.