### PR TITLE
Show empty-state hint on manga page when no download links exist

### DIFF
--- a/Frontend/app/components/DownloadLink/List.vue
+++ b/Frontend/app/components/DownloadLink/List.vue
@@ -1,11 +1,25 @@
 <template>
-    <TrangaList :loading="loading">
+    <UEmpty
+        v-if="!loading && !downloadLinks?.length && emptyTitle"
+        icon="i-lucide-download"
+        :title="emptyTitle"
+        :description="emptyDescription"
+        :actions="emptyActions"
+        class="mt-4" />
+    <TrangaList v-else :loading="loading">
         <DownloadLinkListCard v-for="downloadLink in downloadLinks" :key="downloadLink.downloadId" :download-link="downloadLink" />
     </TrangaList>
 </template>
 
 <script setup lang="ts">
 import type { ServicesMangaMangaDownloadLink } from '~/api/tranga';
+import type { ButtonProps } from '@nuxt/ui/components/Button.vue';
 
-defineProps<{ loading?: boolean; downloadLinks?: ServicesMangaMangaDownloadLink[] }>();
+defineProps<{
+    loading?: boolean;
+    downloadLinks?: ServicesMangaMangaDownloadLink[];
+    emptyTitle?: string;
+    emptyDescription?: string;
+    emptyActions?: ButtonProps[];
+}>();
 </script>

--- a/Frontend/app/pages/manga/[mangaId]/index.vue
+++ b/Frontend/app/pages/manga/[mangaId]/index.vue
@@ -1,6 +1,11 @@
 <template>
     <MangaPage :manga="manga" :actions="actions" :loading="statusManga !== 'success'">
-        <DownloadLinkList :download-links="downloadLinks" :loading="statusDownloadLinks !== 'success'" />
+        <DownloadLinkList
+            :download-links="downloadLinks"
+            :loading="statusDownloadLinks !== 'success'"
+            empty-title="No Download Links"
+            empty-description="This manga doesn't have any download links yet."
+            :empty-actions="[moreDownloadLinksAction]" />
     </MangaPage>
 </template>
 
@@ -29,8 +34,15 @@ const { data: libraryMappings } = useTranga<GetLibrariesMappingsByMangaIdRespons
     key: ApiKeys.Libraries.Mapping(mangaId),
 });
 
-const actions = (manga?: ServicesMangaManga): ButtonProps[] | undefined => [
-    { label: 'More Download-Links', to: `/manga/${manga?.mangaId}/downloadLinks`, icon: 'i-lucide-download', variant: 'outline' },
+const moreDownloadLinksAction = computed<ButtonProps>(() => ({
+    label: 'More Download-Links',
+    to: `/manga/${mangaId}/downloadLinks`,
+    icon: 'i-lucide-download',
+    variant: 'outline',
+}));
+
+const actions = (_manga?: ServicesMangaManga): ButtonProps[] | undefined => [
+    moreDownloadLinksAction.value,
     ...(libraryMappings.value ?? []).map(
         (mapping): ButtonProps => ({
             label: 'View in Komga',


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                             
  - The manga page (`/manga/{id}`) previously rendered an empty list with no explanation when a manga had zero download links.                                                                                                                                           
  - Adds an empty-state hint (`UEmpty`) with a "More Download-Links" call-to-action, reusing the exact same action object as the sidebar's "More Download-Links" button so both link to `/manga/{id}/downloadLinks` identically.                                         
  - The search-results page (`downloadLinks.vue`) reuses the same `DownloadLinkList` component but doesn't opt into the empty-state props, so its behavior is unchanged.                                                                                                 
                                                                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                                                                           
  - [x] `npm run typecheck`                                                                                                                                                                                                                                              
  - [x] `npm run lint`                                                                                                                                                                                                                                                   
  - [x] `npm run build` (dry run) completes with no errors                                                                                                                                                                                                               
  - [ ] Manual check in a running dev stack: manga with no download links shows the hint and the button navigates to `/manga/{id}/downloadLinks`; manga with existing download links renders the list as before 