### PR TITLE
Add Library Root Path field to Komga add-library form

### DIFF
--- a/Frontend/app/pages/settings/libraries.vue
+++ b/Frontend/app/pages/settings/libraries.vue
@@ -20,6 +20,12 @@
                                 <UFormField label="Base URL" name="baseUrl">
                                     <UInput v-model="state.baseUrl" class="w-full" />
                                 </UFormField>
+                                <UFormField
+                                    label="Library Root Path"
+                                    name="libraryRootPath"
+                                    description="Path inside the Komga container where Tranga's manga volume is mounted. Defaults to /tranga.">
+                                    <UInput v-model="state.libraryRootPath" placeholder="/tranga" class="w-full" />
+                                </UFormField>
                             </UForm>
                             <UTabs v-model="active" :items="items" orientation="vertical" value-key="slot" class="h-40">
                                 <template #credentials>
@@ -93,7 +99,7 @@ const items = [
 
 const { data: libraries } = useTranga<GetLibrariesResponse>('/libraries', { key: Libraries.Libraries });
 
-const state = ref<{ name?: string; baseUrl?: string; username?: string; password?: string; apiKey?: string }>({});
+const state = ref<{ name?: string; baseUrl?: string; libraryRootPath?: string; username?: string; password?: string; apiKey?: string }>({});
 
 const connectionVerified = ref(false);
 
@@ -129,10 +135,16 @@ const createLibrary = async () => {
             method: 'put',
             body:
                 active.value === 'apiKey'
-                    ? { name: state.value.name, baseUrl: state.value.baseUrl, apiKey: state.value.apiKey }
+                    ? {
+                          name: state.value.name,
+                          baseUrl: state.value.baseUrl,
+                          libraryRootPath: state.value.libraryRootPath,
+                          apiKey: state.value.apiKey,
+                      }
                     : {
                           name: state.value.name,
                           baseUrl: state.value.baseUrl,
+                          libraryRootPath: state.value.libraryRootPath,
                           username: state.value.username,
                           password: state.value.password,
                       },

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@
 sudo chown -R 1654:1654 /path/to/your/Manga
 ```
 
+### Adding a Komga library
+
+When adding a Komga library, the "Library Root Path" must be the path *inside the Komga container* where Tranga's `Mangas` volume is mounted — not the path on the host, and not the path inside Tranga's own containers. Mount that same volume into your Komga container and point the field at wherever you mounted it (defaults to `/tranga` if left blank).
+
 ## Screenshots
 
 <img src="Screenshots/startpage.png" width="512" alt="start page"/>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                             
  - Adding a Komga library was failing with `Library root folder does not exist: file:/tranga` because the Komga container's manga volume wasn't mounted at the hardcoded default path, and the frontend had no way to override it.                                      
  - The backend already accepted an optional `libraryRootPath` on `AddKomgaLibraryRequest` (defaulting to `/tranga`), but the "Add Library" form on the Libraries settings page never surfaced it.                                                                       
  - Adds a "Library Root Path" field to the form, wired into both the API-key and username/password submission paths, with a description explaining it must match the path where Tranga's manga volume is mounted inside the Komga container.                            
                                                                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                                                                           
  - [x] `npx vue-tsc --noEmit` passes with no errors introduced                                                                                                                                                                                                          
  - [x] `npx prettier --check` clean after formatting                                                                                                                                                                                                                    
  - [ ] Manually verify in the running frontend: add a Komga library with a custom root path and confirm it reaches the backend and Komga accepts it   