### PR TITLE
Add per-task logs, queryable via GET /tasks/{taskId}/logs

### DIFF
--- a/Services.Tasks.Tests/Features/TaskEndpointsTests.cs
+++ b/Services.Tasks.Tests/Features/TaskEndpointsTests.cs
@@ -295,6 +295,64 @@ public class GetTaskEndpointTests : TrangaTest
     }
 }
 
+public class GetTaskLogsEndpointTests : TrangaTest, IDisposable
+{
+    public void Dispose()
+    {
+        TasksCollection.PeriodicTasks.Clear();
+        TasksCollection.RunOnceTasks.Clear();
+    }
+
+    [Fact]
+    public void GetTaskLogs_Returns404ForUnknownId()
+    {
+        TasksCollection.PeriodicTasks.Clear();
+        TasksCollection.RunOnceTasks.Clear();
+
+        Results<Ok<Services.Tasks.Entities.TaskLogEntry[]>, NotFound> result = GetTaskLogsEndpoint.Handle(Guid.NewGuid());
+
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public void GetTaskLogs_ReturnsEntriesInChronologicalOrder()
+    {
+        TasksCollection.PeriodicTasks.Clear();
+        TasksCollection.RunOnceTasks.Clear();
+
+        TestRunOnceTask task = TestTask.Create<TestRunOnceTask>();
+        task.AppendLog(Microsoft.Extensions.Logging.LogLevel.Information, "first");
+        task.AppendLog(Microsoft.Extensions.Logging.LogLevel.Warning, "second");
+        task.AppendLog(Microsoft.Extensions.Logging.LogLevel.Error, "third");
+        TasksCollection.RunOnceTasks.TryAdd(task.TaskId, task);
+
+        Results<Ok<Services.Tasks.Entities.TaskLogEntry[]>, NotFound> result = GetTaskLogsEndpoint.Handle(task.TaskId);
+
+        Ok<Services.Tasks.Entities.TaskLogEntry[]> ok = Assert.IsType<Ok<Services.Tasks.Entities.TaskLogEntry[]>>(result.Result);
+        Assert.NotNull(ok.Value);
+        Assert.Equal(["first", "second", "third"], ok.Value.Select(e => e.Message));
+        Assert.Equal(["Information", "Warning", "Error"], ok.Value.Select(e => e.Level));
+    }
+
+    [Fact]
+    public void GetTaskLogs_SupportsSkipAndLimit()
+    {
+        TasksCollection.PeriodicTasks.Clear();
+        TasksCollection.RunOnceTasks.Clear();
+
+        TestRunOnceTask task = TestTask.Create<TestRunOnceTask>();
+        for (int i = 0; i < 5; i++)
+            task.AppendLog(Microsoft.Extensions.Logging.LogLevel.Information, $"entry {i}");
+        TasksCollection.RunOnceTasks.TryAdd(task.TaskId, task);
+
+        Results<Ok<Services.Tasks.Entities.TaskLogEntry[]>, NotFound> result = GetTaskLogsEndpoint.Handle(task.TaskId, skip: 2, limit: 2);
+
+        Ok<Services.Tasks.Entities.TaskLogEntry[]> ok = Assert.IsType<Ok<Services.Tasks.Entities.TaskLogEntry[]>>(result.Result);
+        Assert.NotNull(ok.Value);
+        Assert.Equal(["entry 2", "entry 3"], ok.Value.Select(e => e.Message));
+    }
+}
+
 public class TaskEndpointsConsistencyTests : TrangaTest, IDisposable
 {
     public void Dispose()

--- a/Services.Tasks.Tests/Helpers/NoOpLogger.cs
+++ b/Services.Tasks.Tests/Helpers/NoOpLogger.cs
@@ -39,6 +39,25 @@ internal sealed class NoOpLogger<T> : ILogger<T>
     }
 }
 
+/// <summary>
+/// An <see cref="ILogger"/> that reports every level as enabled (unlike <see cref="NoOpLogger"/>, whose
+/// <see cref="IsEnabled"/> always returns false) but otherwise does nothing - used where a test needs log calls to
+/// actually reach the logger (e.g. through a decorator like <see cref="Services.Tasks.WorkerLogic.TaskCapturingLogger"/>).
+/// </summary>
+internal sealed class AlwaysEnabledNoOpLogger : ILogger
+{
+    public static AlwaysEnabledNoOpLogger Instance { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoOpLogger.Instance.BeginScope(state);
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+    }
+}
+
 internal sealed class NoOpLoggerFactory : ILoggerFactory
 {
     public static NoOpLoggerFactory Instance { get; } = new();

--- a/Services.Tasks.Tests/WorkerLogic/TaskCapturingLoggerTests.cs
+++ b/Services.Tasks.Tests/WorkerLogic/TaskCapturingLoggerTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging;
+using Services.Tasks.Tests.Helpers;
+using Services.Tasks.WorkerLogic;
+
+namespace Services.Tasks.Tests.WorkerLogic;
+
+public class TaskCapturingLoggerTests
+{
+    [Fact]
+    public void Log_ForwardsToInnerLogger()
+    {
+        RecordingLogger inner = new();
+        TestRunOnceTask task = TestTask.Create<TestRunOnceTask>();
+        TaskCapturingLogger logger = new(inner, task);
+
+        logger.Log(LogLevel.Information, default, "hello", null, (s, _) => s);
+
+        Assert.Single(inner.Entries);
+        Assert.Equal(LogLevel.Information, inner.Entries[0].Level);
+        Assert.Equal("hello", inner.Entries[0].Message);
+    }
+
+    [Fact]
+    public void Log_AppendsToTaskLogEntries()
+    {
+        RecordingLogger inner = new();
+        TestRunOnceTask task = TestTask.Create<TestRunOnceTask>();
+        TaskCapturingLogger logger = new(inner, task);
+
+        logger.Log(LogLevel.Warning, default, "state", null, (_, _) => "message text");
+
+        Services.Tasks.TaskTypes.TaskLogEntry entry = Assert.Single(task.LogEntries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal("message text", entry.Message);
+    }
+
+    [Fact]
+    public void Log_WithException_AppendsExceptionDetailsToMessage()
+    {
+        RecordingLogger inner = new();
+        TestRunOnceTask task = TestTask.Create<TestRunOnceTask>();
+        TaskCapturingLogger logger = new(inner, task);
+        InvalidOperationException exception = new("boom");
+
+        logger.Log(LogLevel.Error, default, "state", exception, (_, _) => "failed");
+
+        Services.Tasks.TaskTypes.TaskLogEntry entry = Assert.Single(task.LogEntries);
+        Assert.Contains("failed", entry.Message);
+        Assert.Contains("boom", entry.Message);
+    }
+
+    [Fact]
+    public void Log_TrimsOldestEntriesBeyondMaxLogEntries()
+    {
+        RecordingLogger inner = new();
+        TestRunOnceTask task = TestTask.Create<TestRunOnceTask>();
+        TaskCapturingLogger logger = new(inner, task);
+
+        for (int i = 0; i < Services.Tasks.TaskTypes.TaskBase.MaxLogEntries + 10; i++)
+            logger.Log(LogLevel.Information, default, i, null, (s, _) => $"message {s}");
+
+        Assert.Equal(Services.Tasks.TaskTypes.TaskBase.MaxLogEntries, task.LogEntries.Count);
+        Assert.Contains(task.LogEntries, e => e.Message == $"message {Services.Tasks.TaskTypes.TaskBase.MaxLogEntries + 9}");
+        Assert.DoesNotContain(task.LogEntries, e => e.Message == "message 0");
+    }
+
+    [Fact]
+    public void BeginScope_And_IsEnabled_ForwardToInnerLogger()
+    {
+        RecordingLogger inner = new();
+        TestRunOnceTask task = TestTask.Create<TestRunOnceTask>();
+        TaskCapturingLogger logger = new(inner, task);
+
+        Assert.Equal(inner.IsEnabled(LogLevel.Debug), logger.IsEnabled(LogLevel.Debug));
+        using IDisposable? scope = logger.BeginScope("scope");
+        Assert.Equal(1, inner.BeginScopeCalls);
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        internal readonly List<(LogLevel Level, string Message)> Entries = new();
+        internal int BeginScopeCalls;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            BeginScopeCalls++;
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/Services.Tasks.Tests/WorkerLogic/TaskWorkerTests.cs
+++ b/Services.Tasks.Tests/WorkerLogic/TaskWorkerTests.cs
@@ -17,7 +17,7 @@ public class TaskWorkerTests
 
         IServiceProvider services = new ServiceCollection().BuildServiceProvider();
         WorkerRuntimeState state = new(Guid.CreateVersion7());
-        TaskWorker worker = new(Guid.CreateVersion7(), queue, services, state, NoOpLogger.Instance);
+        TaskWorker worker = new(Guid.CreateVersion7(), queue, services, state, AlwaysEnabledNoOpLogger.Instance);
 
         using CancellationTokenSource cts = new();
         Task runLoop = worker.RunAsync(cts.Token);
@@ -26,6 +26,7 @@ public class TaskWorkerTests
 
         Assert.Equal(TaskState.Completed, task.Status);
         Assert.Equal(WorkerStatus.Idle, state.Status);
+        Assert.NotEmpty(task.LogEntries);
 
         cts.Cancel();
         await runLoop;

--- a/Services.Tasks/Entities/TaskLogEntry.cs
+++ b/Services.Tasks/Entities/TaskLogEntry.cs
@@ -1,0 +1,11 @@
+namespace Services.Tasks.Entities;
+
+/// <summary>
+/// A single captured log line emitted while a Task executed.
+/// </summary>
+public sealed record TaskLogEntry
+{
+    public required DateTimeOffset Timestamp { get; init; }
+    public required string Level { get; init; }
+    public required string Message { get; init; }
+}

--- a/Services.Tasks/Features/Endpoints.cs
+++ b/Services.Tasks/Features/Endpoints.cs
@@ -27,7 +27,10 @@ internal static class EndpointHelpers
 
         builder.MapGet("{taskId}", GetTaskEndpoint.Handle)
             .WithSummary("Get Task");
-        
+
+        builder.MapGet("{taskId}/logs", GetTaskLogsEndpoint.Handle)
+            .WithSummary("Get Log entries for a Task");
+
         builder.MapGroup("/create").CreateTaskEndpoints();
         
         builder.MapGroup("/manga").RelatedToMangaEndpoints();

--- a/Services.Tasks/Features/Tasks/GetTaskLogsEndpoint.cs
+++ b/Services.Tasks/Features/Tasks/GetTaskLogsEndpoint.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Services.Tasks.WorkerLogic;
+using TaskLogEntry = Services.Tasks.Entities.TaskLogEntry;
+
+namespace Services.Tasks.Features.Tasks;
+
+/// <summary>
+/// <inheritdoc cref="Handle"/>
+/// </summary>
+internal abstract class GetTaskLogsEndpoint
+{
+    /// <summary>
+    /// Get Log entries for a Task, oldest first
+    /// </summary>
+    /// <param name="taskId">ID of Task</param>
+    /// <param name="skip">Number of Log entries to skip (for pagination)</param>
+    /// <param name="limit">Maximum number of Log entries to return</param>
+    /// <returns>A page of Log entries, ordered chronologically</returns>
+    /// <response code="200">A page of Log entries</response>
+    /// <response code="404">Task with requested ID does not exist</response>
+    public static Results<Ok<TaskLogEntry[]>, NotFound> Handle(
+        [FromRoute] Guid taskId,
+        [FromQuery(Name = "skip")] int skip = 0,
+        [FromQuery(Name = "limit")] int limit = 200)
+    {
+        if (TasksCollection.GetTask(taskId) is not { } task)
+            return TypedResults.NotFound();
+
+        TaskLogEntry[] result = task.LogEntries
+            .Skip(skip)
+            .Take(limit)
+            .Select(e => new TaskLogEntry { Timestamp = e.Timestamp, Level = e.Level.ToString(), Message = e.Message })
+            .ToArray();
+        return TypedResults.Ok(result);
+    }
+}

--- a/Services.Tasks/TaskTypes/TaskBase.cs
+++ b/Services.Tasks/TaskTypes/TaskBase.cs
@@ -1,4 +1,11 @@
+using System.Collections.Concurrent;
+
 namespace Services.Tasks.TaskTypes;
+
+/// <summary>
+/// A single captured log line emitted while a <see cref="TaskBase"/> executed.
+/// </summary>
+internal sealed record TaskLogEntry(DateTimeOffset Timestamp, LogLevel Level, string Message);
 
 /// <summary>
 /// A Task
@@ -7,6 +14,12 @@ namespace Services.Tasks.TaskTypes;
 /// <param name="taskTypeId">A <b>unique</b> (across all <see cref="TaskBase"/>) that identifies what type of Task this is.</param>
 internal abstract class TaskBase(TaskType t, Guid taskTypeId) : ITask
 {
+    /// <summary>
+    /// Maximum number of <see cref="TaskLogEntry"/> retained per Task - older entries are dropped once exceeded,
+    /// to bound memory growth for long-lived <see cref="PeriodicTask"/> instances that run repeatedly.
+    /// </summary>
+    internal const int MaxLogEntries = 200;
+
     public Guid TaskId { get; init; } = Guid.CreateVersion7();
 
     public int Priority { get; set; } = 0;
@@ -18,6 +31,15 @@ internal abstract class TaskBase(TaskType t, Guid taskTypeId) : ITask
     public DateTimeOffset? LastRun { get; set; } = null;
 
     public TaskState Status { get; set; } = TaskState.Pending;
+
+    internal ConcurrentQueue<TaskLogEntry> LogEntries { get; } = new();
+
+    internal void AppendLog(LogLevel level, string message)
+    {
+        LogEntries.Enqueue(new TaskLogEntry(DateTimeOffset.UtcNow, level, message));
+        while (LogEntries.Count > MaxLogEntries)
+            LogEntries.TryDequeue(out _);
+    }
 
     /// <summary>
     /// <see cref="TaskTypeId"/>s of Tasks that must reach a terminal <see cref="TaskState"/> (<see cref="TaskState.Completed"/>

--- a/Services.Tasks/WorkerLogic/TaskCapturingLogger.cs
+++ b/Services.Tasks/WorkerLogic/TaskCapturingLogger.cs
@@ -1,0 +1,21 @@
+using Services.Tasks.TaskTypes;
+
+namespace Services.Tasks.WorkerLogic;
+
+/// <summary>
+/// An <see cref="ILogger"/> decorator that forwards every call to <paramref name="inner"/> unchanged, and also
+/// mirrors it into <paramref name="task"/>'s <see cref="TaskBase.LogEntries"/> so it can be queried per Task later.
+/// </summary>
+internal sealed class TaskCapturingLogger(ILogger inner, TaskBase task) : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => inner.BeginScope(state);
+
+    public bool IsEnabled(LogLevel logLevel) => inner.IsEnabled(logLevel);
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        inner.Log(logLevel, eventId, state, exception, formatter);
+        string message = formatter(state, exception);
+        task.AppendLog(logLevel, exception is null ? message : $"{message}\n{exception}");
+    }
+}

--- a/Services.Tasks/WorkerLogic/TaskWorker.cs
+++ b/Services.Tasks/WorkerLogic/TaskWorker.cs
@@ -30,7 +30,8 @@ internal sealed class TaskWorker(Guid workerId, TaskQueue queue, IServiceProvide
                 {
                     state.OnTaskPickedUp(workItem);
                     logger.LogInformation("{workItem} running.", workItem);
-                    await workItem.ExecuteAsync(serviceProvider.CreateScope(), logger, stoppingToken);
+                    ILogger taskLogger = new TaskCapturingLogger(logger, workItem);
+                    await workItem.ExecuteAsync(serviceProvider.CreateScope(), taskLogger, stoppingToken);
                     state.OnTaskFinished();
                 }
                 else

--- a/Services.Tasks/openapi/Services.Tasks.json
+++ b/Services.Tasks/openapi/Services.Tasks.json
@@ -149,6 +149,69 @@
         }
       }
     },
+    "/tasks/{taskId}/logs": {
+      "get": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Get Log entries for a Task",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32",
+              "default": 200
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TaskLogEntry"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
     "/tasks/create/getMangaChapters/{mangaId}": {
       "put": {
         "tags": [
@@ -436,6 +499,26 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "TaskLogEntry": {
+        "required": [
+          "timestamp",
+          "level",
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "level": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
Wraps the ILogger passed into TaskBase.ExecuteAsync/RunAsync with a TaskCapturingLogger decorator that mirrors every log call into a bounded in-memory buffer on the task itself, so existing logger.LogX call sites in concrete tasks need no changes. Logs are ephemeral, matching the existing in-memory lifetime of tasks (TasksCollection).