### PR TITLE
Fix chapters being re-queued for download on every restart

### DIFF
--- a/Services.Tasks/Tasks/DownloadChapterTask.cs
+++ b/Services.Tasks/Tasks/DownloadChapterTask.cs
@@ -94,6 +94,7 @@ internal sealed class DownloadChapterTask(Guid mangaId, Guid chapterId)
         await archive.DisposeAsync();
         await dbFile.SaveFile(archiveStream, stoppingToken);
         await _ctx.AddAsync(dbFile, stoppingToken);
+        link.FileId = dbFile.FileId;
 
         await _ctx.SaveChangesAsync(stoppingToken);
 


### PR DESCRIPTION
DownloadChapterTask created and saved the DbFile for a completed download but never linked it back to the DbChapterDownloadLink via FileId, which is the only signal used to determine whether a chapter is already downloaded (both the "already downloaded" guard in this task and MissingChapterScanTask's query rely on FileId being set). Since it was never persisted, every restart re-queued and re-downloaded every chapter regardless of prior completion.