### PR TITLE
Add CSV export button to the task log page

### DIFF
--- a/Frontend/app/pages/tasks/[taskId].vue
+++ b/Frontend/app/pages/tasks/[taskId].vue
@@ -18,6 +18,15 @@
                     <TrangaTime v-if="task.lastRun" prefix="Last run" :model-value="task.lastRun" relative />
                 </template>
                 <USkeleton v-else class="h-lh w-64" />
+
+                <UButton
+                    class="ml-auto"
+                    icon="i-lucide-download"
+                    label="Export CSV"
+                    variant="outline"
+                    color="neutral"
+                    :disabled="!logs?.length"
+                    @click="exportLogsCsv" />
             </div>
         </UPageSection>
         <UPageSection :ui="{ container: 'px-0 max-w-none sm:py-0 lg:py-0 gap-8 sm:gap-8' }">
@@ -44,6 +53,15 @@ const {
 } = await useTranga<GetTasksByTaskIdLogsResponse>(() => `/tasks/${taskId}/logs?limit=500`, { key: ApiKeys.Tasks.Logs(taskId), lazy: true });
 
 const refresh = () => Promise.all([refreshTask(), refreshLogs()]);
+
+function exportLogsCsv() {
+    if (!logs.value?.length) return;
+    downloadCsv(
+        `task-${taskId}-logs.csv`,
+        ['Timestamp', 'Level', 'Message'],
+        logs.value.map((entry) => [entry.timestamp, entry.level, entry.message]),
+    );
+}
 
 defineShortcuts({ meta_r: () => refresh() });
 

--- a/Frontend/app/utils/downloadCsv.ts
+++ b/Frontend/app/utils/downloadCsv.ts
@@ -1,0 +1,15 @@
+function escapeCsvField(value: string): string {
+    if (/[",\n\r]/.test(value)) return `"${value.replaceAll('"', '""')}"`;
+    return value;
+}
+
+export function downloadCsv(filename: string, headers: string[], rows: string[][]) {
+    const lines = [headers, ...rows].map((row) => row.map(escapeCsvField).join(','));
+    const blob = new Blob([lines.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Adds a client-side downloadCsv util and an "Export CSV" button on tasks/[taskId].vue that downloads the currently loaded log entries as task-{taskId}-logs.csv.