### PR TITLE
Fix Komga library add failing with trailing slash in BaseUrl

### DIFF
--- a/Extensions.Tests/Extensions/KomgaTests.cs
+++ b/Extensions.Tests/Extensions/KomgaTests.cs
@@ -133,4 +133,26 @@ public sealed class KomgaTests : Common.Tests.TrangaTest
 
         await Assert.ThrowsAnyAsync<Exception>(() => KomgaExtension.MintApiKey(server.BaseUrl, "someuser", "wrongpassword", ct));
     }
+
+    [Fact]
+    public async Task MintApiKeyDoesNotDoubleSlashPathWhenBaseUrlHasTrailingSlash()
+    {
+        const string responseBody = """
+        {
+            "comment": "Tranga",
+            "createdDate": "2024-01-01T00:00:00Z",
+            "id": "some-id",
+            "key": "minted-api-key-value",
+            "lastModifiedDate": "2024-01-01T00:00:00Z",
+            "userId": "user-id"
+        }
+        """;
+        using RecordingHttpServer server = new(HttpStatusCode.OK, responseBody);
+
+        // RecordingHttpServer.BaseUrl always has a trailing slash.
+        await KomgaExtension.MintApiKey(server.BaseUrl, "someuser", "somepassword", ct);
+
+        Assert.NotNull(server.LastRequest);
+        Assert.DoesNotContain("//", server.LastRequest!.Url!.AbsolutePath);
+    }
 }

--- a/Extensions/Extensions/Komga.cs
+++ b/Extensions/Extensions/Komga.cs
@@ -19,6 +19,8 @@ public sealed class Komga : ILibraryExtension<KomgaSeries, KomgaBook, StringIden
 
     public Komga(string baseUrl, string apiKey)
     {
+        baseUrl = baseUrl.TrimEnd('/');
+
         _komgaRequestClient = new RequestClient
         {
             DefaultRequestHeaders = { { "X-API-Key", apiKey } }
@@ -63,6 +65,8 @@ public sealed class Komga : ILibraryExtension<KomgaSeries, KomgaBook, StringIden
     /// </summary>
     public static async Task<string> MintApiKey(string baseUrl, string username, string password, CancellationToken ct)
     {
+        baseUrl = baseUrl.TrimEnd('/');
+
         HttpClientHandler handler = new() { UseCookies = true, };
 
         RequestClient requestClient = new()

--- a/Services.Libraries.Tests/Helpers/DbLibraryToLibraryExtensionTests.cs
+++ b/Services.Libraries.Tests/Helpers/DbLibraryToLibraryExtensionTests.cs
@@ -54,7 +54,7 @@ public sealed class DbLibraryToLibraryExtensionTests : Common.Tests.TrangaTest
         KomgaExtension? extension = InvokeToExtension(libraryService);
 
         Assert.NotNull(extension);
-        Assert.Equal("http://localhost:8080/", GetKomgaBasePath(extension));
+        Assert.Equal("http://localhost:8080", GetKomgaBasePath(extension));
         Assert.Equal("some-api-key", GetKomgaApiKeyHeader(extension));
     }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                            
   - Adding a Komga library fails (400 on AddLibrary via API key, misleading 401 via username/password) when the configured `BaseUrl` has a trailing slash.                                                                                                              
   - Root cause: the generated Komga client concatenates `baseUrl + path` verbatim (`WebRequestPathBuilder.GetFullUri`), producing double-slash paths like `//api/v1/libraries`, which Komga rejects. `AddKomgaEndpoint`/`TestKomgaConnectionEndpoint` then surface      
   this as a generic 400/401.                                                                                                                                                                                                                                            
   - Fix: trim trailing slashes from `baseUrl` in `Extensions/Extensions/Komga.cs` before constructing the generated API clients (constructor and `MintApiKey`), since the generated client itself must not be hand-edited.                                              
                                                                                                                                                                                                                                                                         
   ## Test plan                                                                                                                                                                                                                                                          
   - [x] `dotnet test Extensions.Tests/Extensions.Tests.csproj --filter "FullyQualifiedName~Komga"` — added a regression test asserting no double slash in the request path when `BaseUrl` has a trailing slash.                                                         
   - [x] `dotnet test Services.Libraries.Tests/Services.Libraries.Tests.csproj --filter "FullyQualifiedName~Komga"` — updated an existing test that asserted the old (buggy) trailing-slash-preserved behavior.