### PR TITLE
Register MangaPlus in Services.Manga's frontend-facing extension lists

### DIFF
--- a/Services.Manga.Tests/Features/DownloadLinks/GetDownloadExtensionsEndpointTests.cs
+++ b/Services.Manga.Tests/Features/DownloadLinks/GetDownloadExtensionsEndpointTests.cs
@@ -14,5 +14,6 @@ public class GetDownloadExtensionsEndpointTests
         Assert.NotNull(result.Value);
         Assert.NotEmpty(result.Value.Extensions);
         Assert.Contains(result.Value.Extensions, e => e.Name == "MangaDex");
+        Assert.Contains(result.Value.Extensions, e => e.Name == "MangaPlus");
     }
 }

--- a/Services.Manga.Tests/Features/Metadata/GetMetadataExtensionsEndpointTests.cs
+++ b/Services.Manga.Tests/Features/Metadata/GetMetadataExtensionsEndpointTests.cs
@@ -15,5 +15,6 @@ public class GetMetadataExtensionsEndpointTests
         Assert.NotEmpty(result.Value.Extensions);
         Assert.Contains(result.Value.Extensions, e => e.Name == "MangaDex");
         Assert.Contains(result.Value.Extensions, e => e.Name == "MangaUpdates");
+        Assert.Contains(result.Value.Extensions, e => e.Name == "MangaPlus");
     }
 }

--- a/Services.Manga/Entities/DownloadExtensions/DownloadExtension.cs
+++ b/Services.Manga/Entities/DownloadExtensions/DownloadExtension.cs
@@ -27,3 +27,10 @@ public sealed record AsuraScans : IDownloadExtension
     public string Name => "AsuraScans";
     public string IconUrl => "https://asurascans.com/images/logo.webp";
 };
+
+public sealed record MangaPlus : IDownloadExtension
+{
+    public Guid DownloadExtensionsId => Guid.Parse("0bc30bc2-dbcf-47ce-a890-c8428a7e031b");
+    public string Name => "MangaPlus";
+    public string IconUrl => "https://mangaplus.shueisha.co.jp/apple-touch-icon.png";
+};

--- a/Services.Manga/Entities/DownloadExtensions/DownloadExtensionsList.cs
+++ b/Services.Manga/Entities/DownloadExtensions/DownloadExtensionsList.cs
@@ -6,6 +6,7 @@ public sealed record DownloadExtensionsList
     [
         new MangaDex(),
         new WeebCentral(),
-        new AsuraScans()
+        new AsuraScans(),
+        new MangaPlus()
     ];
 }

--- a/Services.Manga/Entities/MetadataExtensions/MetadataExtension.cs
+++ b/Services.Manga/Entities/MetadataExtensions/MetadataExtension.cs
@@ -21,3 +21,10 @@ public sealed record MangaUpdates : IMetadataExtension
     public string Name => "MangaUpdates";
     public string IconUrl => "https://www.mangaupdates.com/images/manga-updates.svg";
 }
+
+public sealed record MangaPlus : IMetadataExtension
+{
+    public Guid MetadataExtensionId => Guid.Parse("0bc30bc2-dbcf-47ce-a890-c8428a7e031b");
+    public string Name => "MangaPlus";
+    public string IconUrl => "https://mangaplus.shueisha.co.jp/apple-touch-icon.png";
+}

--- a/Services.Manga/Entities/MetadataExtensions/MetadataExtensionsList.cs
+++ b/Services.Manga/Entities/MetadataExtensions/MetadataExtensionsList.cs
@@ -5,6 +5,7 @@ public sealed record MetadataExtensionsList
     public IMetadataExtension[] Extensions { get; init; } =
     [
         new MangaDex(),
-        new MangaUpdates()
+        new MangaUpdates(),
+        new MangaPlus()
     ];
 }


### PR DESCRIPTION
The frontend fetches searchable sources from Services.Manga's own DownloadExtensionsList/MetadataExtensionsList, a separate hardcoded registry from Extensions/*Collection.cs. MangaPlus was wired into the latter but missing from the former, so it never showed up as a search option even though the backend search itself already worked.