### PR TITLE
Add more logging to Services.Tasks tasks

### DIFF
--- a/Services.Tasks/Tasks/DbFileCleanupTask.cs
+++ b/Services.Tasks/Tasks/DbFileCleanupTask.cs
@@ -22,12 +22,16 @@ internal sealed class DbFileCleanupTask() : PeriodicTask(Guid.Parse("ded1e7d1-ec
     /// <returns></returns>
     protected override async Task RunAsync(IServiceScope scope, ILogger logger, CancellationToken stoppingToken)
     {
+        logger.LogDebug("Searching for orphaned {nameof(DbFile)}...", nameof(DbFile));
         int amount = await _ctx.Files.Where(f =>
             _ctx.ChapterDownloadLinks.Select(c => c.FileId).Union(_ctx.MetadataEntries.Select(m => m.CoverId))
                 .Union(_ctx.DownloadLinks.Select(d => d.CoverId))
                 .Any(i => i == f.FileId)
         ).ExecuteDeleteAsync(stoppingToken);
-        logger.LogDebug("Removed {amount} {nameof(DbFile)}", amount, nameof(DbFile));
+        if (amount > 0)
+            logger.LogInformation("Removed {amount} orphaned {nameof(DbFile)}", amount, nameof(DbFile));
+        else
+            logger.LogDebug("No orphaned {nameof(DbFile)} found.", nameof(DbFile));
     }
 
     protected override void RefreshScope(IServiceScope scope)

--- a/Services.Tasks/Tasks/DownloadChapterTask.cs
+++ b/Services.Tasks/Tasks/DownloadChapterTask.cs
@@ -36,10 +36,12 @@ internal sealed class DownloadChapterTask(Guid mangaId, Guid chapterId)
 
     protected override async Task RunAsync(IServiceScope scope, ILogger logger, CancellationToken stoppingToken)
     {
+        logger.LogDebug("Downloading Chapter {ChapterId} of Manga {MangaId}...", ChapterId, MangaId);
         if (await _ctx.Chapters.Include(c => c.DownloadLinks)
                 .SingleOrDefaultAsync(c => c.ChapterId == ChapterId, stoppingToken)
             is not { } chapter)
         {
+            logger.LogError("Could not find Chapter {ChapterId}", ChapterId);
             return;
         }
 
@@ -50,16 +52,25 @@ internal sealed class DownloadChapterTask(Guid mangaId, Guid chapterId)
         }
 
         if (chapter.DownloadLinks!.MinBy(d => d.Priority) is not { } link)
+        {
+            logger.LogWarning("Chapter {ChapterId} has no DownloadLinks.", ChapterId);
             return;
+        }
         logger.LogDebug("Got {link.DownloadExtension} {link.Identifier}.", link.DownloadExtension, link.Identifier);
         if (DownloadExtensionsCollection.GetExtension(link.DownloadExtension) is not { } extension)
+        {
+            logger.LogError("Could not find {nameof(IDownloadExtension)} {link.DownloadExtension}",
+                nameof(IDownloadExtension), link.DownloadExtension);
             return;
+        }
 
+        logger.LogDebug("Getting Chapter images...");
         if (await extension.GetChapterImages(link.ToChapterInfo(), stoppingToken) is not { } images)
         {
             logger.LogError("Could not get images!");
             return;
         }
+        logger.LogDebug("Got {images.Count} images.", images.Count);
 
         // Create archive
         using MemoryStream archiveStream = new();
@@ -71,6 +82,7 @@ internal sealed class DownloadChapterTask(Guid mangaId, Guid chapterId)
             image.image.Position = 0;
             await image.image.CopyToAsync(entryStream, stoppingToken);
         }
+        logger.LogTrace("Built archive with {images.Count} entries.", images.Count);
 
         // Get Manga directory Path
         if (await _ctx.GetManga(MangaId, stoppingToken) is not { Metadata: { Series: { } seriesName } })
@@ -93,6 +105,7 @@ internal sealed class DownloadChapterTask(Guid mangaId, Guid chapterId)
         // For some reason you need to dispose the archive to write headers
         await archive.DisposeAsync();
         await dbFile.SaveFile(archiveStream, stoppingToken);
+        logger.LogDebug("Saved File {dbFile.FullPath}", dbFile.FullPath);
         await _ctx.AddAsync(dbFile, stoppingToken);
         link.FileId = dbFile.FileId;
 
@@ -101,6 +114,8 @@ internal sealed class DownloadChapterTask(Guid mangaId, Guid chapterId)
         await scope.ServiceProvider.GetRequiredService<EventPublisher>().PublishAsync(
             new ChapterDownloadedEvent(dbFile.FullPath, MangaId, seriesName, chapter.Number, chapter.Title, chapter.Volume),
             stoppingToken);
+        logger.LogInformation("Downloaded Chapter {chapter.Number} of {seriesName} to {dbFile.FullPath}",
+            chapter.Number, seriesName, dbFile.FullPath);
     }
 
     protected override void RefreshScope(IServiceScope scope)

--- a/Services.Tasks/Tasks/GetMangaChaptersTask.cs
+++ b/Services.Tasks/Tasks/GetMangaChaptersTask.cs
@@ -20,12 +20,13 @@ internal sealed class GetMangaChaptersTask(Guid mangaId) : RunOnceTask(GetMangaC
     
     protected override async Task RunAsync(IServiceScope scope, ILogger logger, CancellationToken stoppingToken)
     {
+        logger.LogDebug("Fetching chapters for Manga {MangaId}...", MangaId);
         if (await _ctx.Mangas.Include(m => m.DownloadLinks).SingleOrDefaultAsync(m => m.MangaId == MangaId, stoppingToken) is not { } manga)
         {
             logger.LogError("Could not find Manga {MangaId}", MangaId);
             return;
         }
-        
+
         if (manga.DownloadLinks!.Where(d => d.Matched).MinBy(d => d.Priority)?.DownloadLink is not { } link)
         {
             logger.LogDebug("No Matched DownloadLink");
@@ -49,6 +50,7 @@ internal sealed class GetMangaChaptersTask(Guid mangaId) : RunOnceTask(GetMangaC
         logger.LogDebug("Got {chapters.Count} chapters...", chapters.Count);
 
         DbChapter[] newChapters = chapters.Select(c => c.ToChapter(manga).CreateAndAddChapterDownloadLink(c)).ToArray();
+        int addedLinks = 0, addedChapters = 0, skippedExisting = 0;
         foreach (DbChapterDownloadLink downloadLink in newChapters.SelectMany(c => c.DownloadLinks!))
         {
             logger.LogTrace($"Adding {nameof(DbChapter)} and/or {nameof(DbChapterDownloadLink)}...");
@@ -59,6 +61,7 @@ internal sealed class GetMangaChaptersTask(Guid mangaId) : RunOnceTask(GetMangaC
                 logger.LogTrace(
                     "{nameof(DbChapterDownloadLink)} {downloadLink.DownloadExtension} {downloadLink.Identifier} already exists.",
                     nameof(DbChapterDownloadLink), downloadLink.DownloadExtension, downloadLink.Identifier);
+                skippedExisting++;
                 continue;
             }
 
@@ -75,16 +78,21 @@ internal sealed class GetMangaChaptersTask(Guid mangaId) : RunOnceTask(GetMangaC
                 await _ctx.AddAsync(newLink, stoppingToken);
                 logger.LogDebug("Added {nameof(DbChapterDownloadLink)} to {dbChapter.ChapterId}",
                     nameof(DbChapterDownloadLink), dbChapter.ChapterId);
+                addedLinks++;
             }
             else
             {
                 await _ctx.AddAsync(downloadLink, stoppingToken);
                 logger.LogDebug("Added {nameof(DbChapter)} {chapter.ChapterId}", nameof(DbChapter),
                     downloadLink.ChapterId);
+                addedChapters++;
             }
         }
 
         await _ctx.SaveChangesAsync(stoppingToken);
+        logger.LogInformation(
+            "Manga {MangaId}: added {addedChapters} new Chapters, {addedLinks} new DownloadLinks, skipped {skippedExisting} existing.",
+            MangaId, addedChapters, addedLinks, skippedExisting);
     }
 
     protected override void RefreshScope(IServiceScope scope)

--- a/Services.Tasks/Tasks/MissingChapterScanTask.cs
+++ b/Services.Tasks/Tasks/MissingChapterScanTask.cs
@@ -27,13 +27,16 @@ internal sealed class MissingChapterScanTask() : PeriodicTask(Guid.Parse("9a9e92
             .Where(t => t.Status is not (TaskState.Completed or TaskState.Failed))
             .Select(t => t.ChapterId);
 
+        logger.LogDebug("Scanning for Chapters without downloaded {nameof(DbFile)}...", nameof(DbFile));
         var chaptersWithoutFiles = await _ctx.Chapters.Include(c => c.DownloadLinks)
             .Where(c => !chapterIds.Contains(c.ChapterId) && c.DownloadLinks!.All(d => d.FileId == null))
             .Select(c => new { MangaId = c.MangaId, ChapterId = c.ChapterId, Number = c.Number })
             .GroupBy(c => c.MangaId)
             .ToListAsync(stoppingToken);
+        logger.LogDebug("Found {chaptersWithoutFiles.Count} Mangas with missing Chapters.", chaptersWithoutFiles.Count);
 
         int mangaIndex = 0;
+        int totalTasksAdded = 0;
         foreach (var manga in chaptersWithoutFiles)
         {
             mangaIndex++;
@@ -47,8 +50,12 @@ internal sealed class MissingChapterScanTask() : PeriodicTask(Guid.Parse("9a9e92
             {
                 logger.LogDebug("Adding {nameof(DownloadChapterTask)} for Chapter {task.ChapterId}", nameof(DownloadChapterTask), task.ChapterId);
                 TasksCollection.RunOnceTasks.TryAdd(task.TaskId, task);
+                totalTasksAdded++;
             }
         }
+        if (totalTasksAdded > 0)
+            logger.LogInformation("Queued {totalTasksAdded} {nameof(DownloadChapterTask)} across {chaptersWithoutFiles.Count} Mangas.",
+                totalTasksAdded, nameof(DownloadChapterTask), chaptersWithoutFiles.Count);
     }
 
     /// <summary>

--- a/Services.Tasks/Tasks/PeriodicMangaChapterFetcherTask.cs
+++ b/Services.Tasks/Tasks/PeriodicMangaChapterFetcherTask.cs
@@ -22,6 +22,7 @@ internal sealed class PeriodicMangaChapterFetcherTask() : PeriodicTask(Guid.Pars
         logger.LogDebug("Got {list.Count} Mangas.", list.Count);
 
         IEnumerable<GetMangaChaptersTask> newTasks = list.Select(m => new GetMangaChaptersTask(m));
+        int added = 0, skipped = 0;
         foreach (GetMangaChaptersTask task in newTasks)
         {
             // A completed/failed GetMangaChaptersTask must not block ever re-fetching this Manga again.
@@ -31,12 +32,15 @@ internal sealed class PeriodicMangaChapterFetcherTask() : PeriodicTask(Guid.Pars
             {
                 logger.LogDebug("Adding {nameof(GetMangaChaptersTask)} for Manga {task.MangaId}", nameof(GetMangaChaptersTask), task.MangaId);
                 TasksCollection.RunOnceTasks.TryAdd(task.TaskId, task);
+                added++;
             }
             else
             {
                 logger.LogTrace("Manga {task.MangaId} already has {nameof(GetMangaChaptersTask)} Task.", task.MangaId, nameof(GetMangaChaptersTask));
+                skipped++;
             }
         }
+        logger.LogInformation("Queued {added} {nameof(GetMangaChaptersTask)} ({skipped} already in flight).", added, nameof(GetMangaChaptersTask), skipped);
     }
     
     protected override void RefreshScope(IServiceScope scope)


### PR DESCRIPTION
Add entry/progress/summary log lines (search start, per-run counts, error paths, success confirmations) across DbFileCleanupTask, GetMangaChaptersTask, PeriodicMangaChapterFetcherTask, MissingChapterScanTask, and DownloadChapterTask so task runs are more observable.