### PR TITLE
Fix search results merging across different metadata extensions

### DIFF
--- a/Services.Manga.Tests/Features/Manga/Search/PostSearchMangaEndpointTests.cs
+++ b/Services.Manga.Tests/Features/Manga/Search/PostSearchMangaEndpointTests.cs
@@ -3,6 +3,7 @@ using Common.Helpers;
 using Common.Tests;
 using Extensions.Data;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
 using Services.Manga.Database;
 using Services.Manga.Features.Manga.Search;
 using Services.Manga.Tests.Helpers;
@@ -36,6 +37,51 @@ public class PostSearchMangaEndpointTests : TrangaTest
 
         MetadataDto[] results = Assert.IsType<Ok<MetadataDto[]>>(result.Result).Value!;
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task FindExistingMetadata_DoesNotMatchAcrossDifferentExtensionsWithSameSeries()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+        DbMetadata mangaUpdatesEntry = TestDataBuilder.NewMetadata(series: "One Piece");
+        mangaUpdatesEntry.Url = "https://mangaupdates.com/series/one-piece";
+        await context.AddAsync(mangaUpdatesEntry, ct);
+        await context.SaveChangesAsync(ct);
+
+        SearchResult mangaDexResult = new()
+        {
+            MetadataExtensionIdentifier = Guid.NewGuid(),
+            Identifier = Guid.NewGuid().ToString(),
+            Cover = new TrangaImage(),
+            Series = "One Piece",
+            Url = "https://mangadex.org/title/one-piece"
+        };
+
+        DbMetadata? existing = await PostSearchMangaEndpoint.FindExistingMetadata(context, mangaDexResult, ct);
+
+        Assert.Null(existing);
+    }
+
+    [Fact]
+    public async Task FindExistingMetadata_MatchesSameExtensionBySeriesTitle()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+        DbMetadata mangaUpdatesEntry = TestDataBuilder.NewMetadata(series: "One Piece");
+        await context.AddAsync(mangaUpdatesEntry, ct);
+        await context.SaveChangesAsync(ct);
+
+        SearchResult sameExtensionResult = new()
+        {
+            MetadataExtensionIdentifier = mangaUpdatesEntry.MetadataExtension,
+            Identifier = Guid.NewGuid().ToString(),
+            Cover = new TrangaImage(),
+            Series = "One Piece"
+        };
+
+        DbMetadata? existing = await PostSearchMangaEndpoint.FindExistingMetadata(context, sameExtensionResult, ct);
+
+        Assert.NotNull(existing);
+        Assert.Equal(mangaUpdatesEntry.MetadataId, existing.MetadataId);
     }
 
     [Fact]

--- a/Services.Manga/Features/Manga/Search/PostSearchMangaEndpoint.cs
+++ b/Services.Manga/Features/Manga/Search/PostSearchMangaEndpoint.cs
@@ -42,15 +42,7 @@ internal abstract class PostSearchMangaEndpoint
         
         foreach (SearchResult searchResult in searchResults)
         {
-            if (await mangaContext.MetadataEntries
-                    .Include(s => s.MangaMetadataEntries)
-                    .Include(s => s.Genres)
-                    .Include(s => s.Artists)
-                    .Include(s => s.Authors)
-                    .Where(s =>
-                        s.MetadataExtension == searchResult.MetadataExtensionIdentifier &&
-                        s.Identifier == searchResult.Identifier || s.Series == searchResult.Series)
-                    .FirstOrDefaultAsync(ct) is not { } existing)
+            if (await FindExistingMetadata(mangaContext, searchResult, ct) is not { } existing)
             {
                 DbMetadata metadata = await CreateMetadata(mangaContext, searchResult, ct);
                 metadataList.Add(metadata);
@@ -76,6 +68,25 @@ internal abstract class PostSearchMangaEndpoint
     /// <param name="SearchQuery">Search Query</param>
     /// <param name="MetadataExtensionIds">IDs of Metadata Extensions to Search on</param>
     public sealed record PostSearchMangaRequest(SearchQuery SearchQuery, Guid[]? MetadataExtensionIds);
+
+    /// <summary>
+    /// Looks up a previously-stored <see cref="DbMetadata"/> matching a search result. Matching is scoped to the
+    /// same extension (<see cref="SearchResult.MetadataExtensionIdentifier"/>): a result is only considered the
+    /// same entry as an existing row if it came from the same extension, and either shares the extension's own
+    /// identifier or the same series title. Without the extension scope, two different extensions' results for a
+    /// series with the same title would collapse into one row, silently overwriting fields (e.g. Url) from one
+    /// extension with another's.
+    /// </summary>
+    internal static async Task<DbMetadata?> FindExistingMetadata(MangaContext mangaContext, SearchResult searchResult, CancellationToken ct) =>
+        await mangaContext.MetadataEntries
+            .Include(s => s.MangaMetadataEntries)
+            .Include(s => s.Genres)
+            .Include(s => s.Artists)
+            .Include(s => s.Authors)
+            .Where(s =>
+                s.MetadataExtension == searchResult.MetadataExtensionIdentifier &&
+                (s.Identifier == searchResult.Identifier || s.Series == searchResult.Series))
+            .FirstOrDefaultAsync(ct);
 
     private static async Task<DbMetadata> CreateMetadata(MangaContext mangaContext, SearchResult searchResult, CancellationToken ct)
     {


### PR DESCRIPTION
The existing-metadata lookup in PostSearchMangaEndpoint used `A && B || C` due to operator precedence, so any DbMetadata row with a matching Series title was treated as "already exists" regardless of which extension it came from. This caused a MangaUpdates-sourced row to get its Url/Summary/Year/Status overwritten by a same-titled MangaDex result, while keeping its original MangaUpdates label - making search results look like they always come from one extension.

Scoped the Series-title fallback match to the same extension, and extracted the lookup into FindExistingMetadata for direct testing.