### PR TITLE
Sync Komga metadata on connect and on new manga, backfill links by name

### DIFF
--- a/Common.Tests/Helpers/StringExtensionsTests.cs
+++ b/Common.Tests/Helpers/StringExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Common.Helpers;
+
+namespace Common.Tests.Helpers;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [CombinatorialData]
+    public void SafeFilesystemString_StripsUnsafeCharacters([CombinatorialValues('#', '$', '%', '&', '*', '<', '>', ':', '"', '/', '\\', '|', '?')]char character)
+    {
+        string input = $"a{character}b";
+
+        string result = input.SafeFilesystemString();
+
+        Assert.Equal("ab", result);
+    }
+
+    [Fact]
+    public void SafeFilesystemString_KeepsAlphanumericsDashesDotsUnderscoresAndSpaces()
+    {
+        string input = "Some Series-Name_v2.1";
+
+        string result = input.SafeFilesystemString();
+
+        Assert.Equal(input, result);
+    }
+}

--- a/Common/Helpers/StringExtensions.cs
+++ b/Common/Helpers/StringExtensions.cs
@@ -1,0 +1,15 @@
+using System.Text.RegularExpressions;
+
+namespace Common.Helpers;
+
+public static partial class StringExtensions
+{
+    /// <summary>
+    /// Removes "illegal" characters
+    /// </summary>
+    /// <param name="str"></param>
+    /// <returns></returns>
+    public static string SafeFilesystemString(this string str) => SafeCharacters().Replace(str, string.Empty);
+    [GeneratedRegex(@"[^0-9a-zA-Z-._\ ]")]
+    private static partial Regex SafeCharacters();
+}

--- a/Services.Libraries.Tests/EventHandlers/ChapterDownloadedHandlerTests.cs
+++ b/Services.Libraries.Tests/EventHandlers/ChapterDownloadedHandlerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Reflection;
 using Common.Services.Events.Events;
 using Common.Tests;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -9,6 +10,7 @@ using RabbitMQ.Client;
 using Services.Libraries.Database;
 using Services.Libraries.EventHandlers;
 using Services.Libraries.Tests.Helpers;
+using Services.Manga.Database;
 
 namespace Services.Libraries.Tests.EventHandlers;
 
@@ -25,16 +27,42 @@ public sealed class ChapterDownloadedHandlerTests : TrangaTest, IDisposable
         ChapterDownloadedHandler.SeriesPollInterval = _originalSeriesPollInterval;
     }
 
-    private static ChapterDownloadedHandler CreateHandler(LibrariesContext context)
+    private static ChapterDownloadedHandler CreateHandler(LibrariesContext context, MangaContext? mangaContext = null)
     {
         Mock<IChannel> mockChannel = new();
 
         ServiceCollection services = new();
         services.AddSingleton(context);
+        services.AddSingleton(mangaContext ?? MangaContextFactory.Create());
         services.AddLogging();
         ServiceProvider provider = services.BuildServiceProvider();
 
         return new ChapterDownloadedHandler(mockChannel.Object, provider);
+    }
+
+    private static async Task<(DbManga Manga, DbMetadata Metadata)> SeedMangaWithChosenMetadata(
+        MangaContext context, Guid mangaId, string series, CancellationToken ct)
+    {
+        DbManga manga = new() { MangaId = mangaId, Monitored = true };
+        DbMetadata metadata = new()
+        {
+            MetadataExtension = Guid.NewGuid(),
+            Identifier = Guid.NewGuid().ToString(),
+            Series = series,
+            Summary = "Some summary"
+        };
+        DbMangaMetadataEntries entry = new()
+        {
+            MangaId = manga.MangaId,
+            Chosen = true,
+            Manga = manga,
+            Metadata = metadata
+        };
+
+        await context.AddRangeAsync([manga, metadata, entry], ct);
+        await context.SaveChangesAsync(ct);
+
+        return (manga, metadata);
     }
 
     private static async Task<bool> InvokeHandleMessage(ChapterDownloadedHandler handler, ChapterDownloadedEvent chapterDownloadedEvent)
@@ -232,6 +260,49 @@ public sealed class ChapterDownloadedHandlerTests : TrangaTest, IDisposable
         DbMangaIdMapping? mapping = context.MangaMappings.SingleOrDefault(m => m.LibraryServiceId == library.LibraryServiceId && m.MangaId == mangaId);
         Assert.NotNull(mapping);
         Assert.Equal("new-series-id", mapping.SeriesId);
+    }
+
+    [Fact]
+    public async Task HandleMessage_NoExistingMapping_NewMappingCreated_PushesMetadataToKomga()
+    {
+        ChapterDownloadedHandler.SeriesPollInterval = TimeSpan.FromMilliseconds(1);
+
+        int seriesListCallCount = 0;
+        int metadataUpdateCallCount = 0;
+        using FakeKomgaServer server = new(path =>
+        {
+            if (path.Contains("/scan"))
+                return (HttpStatusCode.OK, null);
+
+            if (path.Contains("/metadata"))
+            {
+                metadataUpdateCallCount++;
+                return (HttpStatusCode.OK, null);
+            }
+
+            seriesListCallCount++;
+            return seriesListCallCount <= 2
+                ? (HttpStatusCode.OK, FakeKomgaServer.EmptySeriesListResponseBody)
+                : (HttpStatusCode.OK, SeriesListBody(("new-series-id", "New Series")));
+        });
+
+        await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
+        DbLibraryService library = NewKomgaLibrary(server.BaseUrl);
+        await context.LibraryServices.AddAsync(library, ct);
+        await context.SaveChangesAsync(ct);
+
+        Guid mangaId = Guid.NewGuid();
+        await SeedMangaWithChosenMetadata(mangaContext, mangaId, "New Series", ct);
+
+        ChapterDownloadedHandler handler = CreateHandler(context, mangaContext);
+
+        bool result = await InvokeHandleMessage(handler, NewEvent(mangaId));
+
+        Assert.True(result);
+        DbMangaIdMapping? mapping = context.MangaMappings.SingleOrDefault(m => m.LibraryServiceId == library.LibraryServiceId && m.MangaId == mangaId);
+        Assert.NotNull(mapping);
+        Assert.Equal(1, metadataUpdateCallCount);
     }
 
     [Fact]

--- a/Services.Libraries.Tests/Features/Libraries/AddKomgaEndpointTests.cs
+++ b/Services.Libraries.Tests/Features/Libraries/AddKomgaEndpointTests.cs
@@ -2,19 +2,49 @@ using System.Net;
 using Common.Tests;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Services.Libraries.Database;
 using Services.Libraries.Features.Libraries;
 using Services.Libraries.Tests.Helpers;
+using Services.Manga.Database;
 
 namespace Services.Libraries.Tests.Features.Libraries;
 
 public sealed class AddKomgaEndpointTests : TrangaTest
 {
+    private static async Task<(DbManga Manga, DbMetadata Metadata)> SeedMangaWithChosenMetadata(
+        MangaContext context, string series, CancellationToken ct)
+    {
+        DbManga manga = new() { MangaId = Guid.NewGuid(), Monitored = true };
+        DbMetadata metadata = new()
+        {
+            MetadataExtension = Guid.NewGuid(),
+            Identifier = Guid.NewGuid().ToString(),
+            Series = series,
+            Summary = "Some summary"
+        };
+        DbMangaMetadataEntries entry = new()
+        {
+            MangaId = manga.MangaId,
+            Chosen = true,
+            Manga = manga,
+            Metadata = metadata
+        };
+
+        await context.AddRangeAsync([manga, metadata, entry], ct);
+        await context.SaveChangesAsync(ct);
+
+        return (manga, metadata);
+    }
+
     [Fact]
     public async Task AddKomga_CreatesLibraryWithApiKey()
     {
-        using FakeKomgaServer server = new(HttpStatusCode.OK, FakeKomgaServer.ValidLibraryCreationResponseBody);
+        using FakeKomgaServer server = new(path => path.Contains("/libraries")
+            ? (HttpStatusCode.OK, FakeKomgaServer.ValidLibraryCreationResponseBody)
+            : (HttpStatusCode.OK, FakeKomgaServer.EmptySeriesListResponseBody));
         await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
 
         AddKomgaEndpoint.AddKomgaLibraryRequest request = new()
         {
@@ -23,7 +53,7 @@ public sealed class AddKomgaEndpointTests : TrangaTest
             ApiKey = "some-api-key"
         };
 
-        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, request, ct);
+        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, mangaContext, request, NullLogger<AddKomgaEndpoint>.Instance, ct);
 
         Guid id = Assert.IsType<Ok<Guid>>(result.Result).Value;
         DbLibraryService? persisted = await context.LibraryServices.FirstOrDefaultAsync(l => l.LibraryServiceId == id, ct);
@@ -37,8 +67,11 @@ public sealed class AddKomgaEndpointTests : TrangaTest
     {
         using FakeKomgaServer server = new(request => request.Contains("api-keys")
             ? (HttpStatusCode.OK, FakeKomgaServer.ValidApiKeyMintResponseBody)
-            : (HttpStatusCode.OK, FakeKomgaServer.ValidLibraryCreationResponseBody));
+            : request.Contains("/libraries")
+                ? (HttpStatusCode.OK, FakeKomgaServer.ValidLibraryCreationResponseBody)
+                : (HttpStatusCode.OK, FakeKomgaServer.EmptySeriesListResponseBody));
         await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
 
         AddKomgaEndpoint.AddKomgaLibraryRequest request = new()
         {
@@ -48,7 +81,7 @@ public sealed class AddKomgaEndpointTests : TrangaTest
             Password = "somepassword"
         };
 
-        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, request, ct);
+        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, mangaContext, request, NullLogger<AddKomgaEndpoint>.Instance, ct);
 
         Guid id = Assert.IsType<Ok<Guid>>(result.Result).Value;
         DbLibraryService? persisted = await context.LibraryServices.FirstOrDefaultAsync(l => l.LibraryServiceId == id, ct);
@@ -62,6 +95,7 @@ public sealed class AddKomgaEndpointTests : TrangaTest
     {
         using FakeKomgaServer server = new(HttpStatusCode.Unauthorized);
         await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
 
         AddKomgaEndpoint.AddKomgaLibraryRequest request = new()
         {
@@ -71,7 +105,7 @@ public sealed class AddKomgaEndpointTests : TrangaTest
             Password = "wrongpassword"
         };
 
-        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, request, ct);
+        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, mangaContext, request, NullLogger<AddKomgaEndpoint>.Instance, ct);
 
         Assert.IsType<BadRequest<string>>(result.Result);
         Assert.Empty(await context.LibraryServices.ToListAsync(ct));
@@ -81,6 +115,7 @@ public sealed class AddKomgaEndpointTests : TrangaTest
     public async Task AddKomga_RejectsWhenNeitherAuthModeGiven()
     {
         await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
 
         AddKomgaEndpoint.AddKomgaLibraryRequest request = new()
         {
@@ -88,7 +123,7 @@ public sealed class AddKomgaEndpointTests : TrangaTest
             BaseUrl = "http://localhost:8080"
         };
 
-        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, request, ct);
+        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, mangaContext, request, NullLogger<AddKomgaEndpoint>.Instance, ct);
 
         Assert.IsType<BadRequest<string>>(result.Result);
         Assert.Empty(await context.LibraryServices.ToListAsync(ct));
@@ -98,6 +133,7 @@ public sealed class AddKomgaEndpointTests : TrangaTest
     public async Task AddKomga_RejectsWhenBothAuthModesGiven()
     {
         await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
 
         AddKomgaEndpoint.AddKomgaLibraryRequest request = new()
         {
@@ -108,9 +144,136 @@ public sealed class AddKomgaEndpointTests : TrangaTest
             Password = "somepassword"
         };
 
-        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, request, ct);
+        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, mangaContext, request, NullLogger<AddKomgaEndpoint>.Instance, ct);
 
         Assert.IsType<BadRequest<string>>(result.Result);
         Assert.Empty(await context.LibraryServices.ToListAsync(ct));
+    }
+
+    [Fact]
+    public async Task AddKomga_LinksExistingMangaByNameAndPushesMetadata()
+    {
+        int metadataUpdateCallCount = 0;
+        using FakeKomgaServer server = new(path =>
+        {
+            if (path.Contains("/libraries"))
+                return (HttpStatusCode.OK, FakeKomgaServer.ValidLibraryCreationResponseBody);
+            if (path.Contains("/metadata"))
+            {
+                metadataUpdateCallCount++;
+                return (HttpStatusCode.OK, null);
+            }
+
+            // GetSeriesList
+            return (HttpStatusCode.OK, ChapterDownloadedHandlerTestsSeriesListBody(("existing-series-id", "My Manga Title")));
+        });
+        await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
+        (DbManga manga, DbMetadata _) = await SeedMangaWithChosenMetadata(mangaContext, "My Manga Title", ct);
+
+        AddKomgaEndpoint.AddKomgaLibraryRequest request = new()
+        {
+            Name = "MyLibrary",
+            BaseUrl = server.BaseUrl,
+            ApiKey = "some-api-key"
+        };
+
+        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, mangaContext, request, NullLogger<AddKomgaEndpoint>.Instance, ct);
+
+        Guid id = Assert.IsType<Ok<Guid>>(result.Result).Value;
+        DbMangaIdMapping? mapping = await context.MangaMappings
+            .SingleOrDefaultAsync(m => m.LibraryServiceId == id && m.MangaId == manga.MangaId, ct);
+        Assert.NotNull(mapping);
+        Assert.Equal("existing-series-id", mapping.SeriesId);
+        Assert.Equal(1, metadataUpdateCallCount);
+    }
+
+    [Fact]
+    public async Task AddKomga_NoMatchingSeriesName_LeavesMangaUnlinked()
+    {
+        using FakeKomgaServer server = new(path => path.Contains("/libraries")
+            ? (HttpStatusCode.OK, FakeKomgaServer.ValidLibraryCreationResponseBody)
+            : (HttpStatusCode.OK, ChapterDownloadedHandlerTestsSeriesListBody(("existing-series-id", "Some Other Series"))));
+        await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
+        (DbManga manga, DbMetadata _) = await SeedMangaWithChosenMetadata(mangaContext, "My Manga Title", ct);
+
+        AddKomgaEndpoint.AddKomgaLibraryRequest request = new()
+        {
+            Name = "MyLibrary",
+            BaseUrl = server.BaseUrl,
+            ApiKey = "some-api-key"
+        };
+
+        Results<Ok<Guid>, BadRequest<string>> result = await AddKomgaEndpoint.Handle(context, mangaContext, request, NullLogger<AddKomgaEndpoint>.Instance, ct);
+
+        Guid id = Assert.IsType<Ok<Guid>>(result.Result).Value;
+        Assert.Empty(await context.MangaMappings.Where(m => m.LibraryServiceId == id && m.MangaId == manga.MangaId).ToListAsync(ct));
+    }
+
+    /// <summary>
+    /// Builds a full Komga "content" SeriesDto JSON array, matching the shape required by
+    /// <see cref="ChapterDownloadedHandlerTests"/>'s SeriesListBody helper (every
+    /// [DataMember(IsRequired = true)] field must be present or the generated client throws).
+    /// </summary>
+    private static string ChapterDownloadedHandlerTestsSeriesListBody(params (string Id, string Name)[] series)
+    {
+        string items = string.Join(",", series.Select(s => $$"""
+        {
+            "id": "{{s.Id}}",
+            "name": "{{s.Name}}",
+            "libraryId": "komga-library-id",
+            "booksCount": 0,
+            "booksInProgressCount": 0,
+            "booksReadCount": 0,
+            "booksUnreadCount": 0,
+            "created": "2024-01-01T00:00:00Z",
+            "deleted": false,
+            "fileLastModified": "2024-01-01T00:00:00Z",
+            "lastModified": "2024-01-01T00:00:00Z",
+            "oneshot": false,
+            "url": "/some/path",
+            "booksMetadata": {
+                "authors": [],
+                "created": "2024-01-01T00:00:00Z",
+                "lastModified": "2024-01-01T00:00:00Z",
+                "summary": "",
+                "summaryNumber": "",
+                "tags": []
+            },
+            "metadata": {
+                "ageRatingLock": false,
+                "alternateTitles": [],
+                "alternateTitlesLock": false,
+                "created": "2024-01-01T00:00:00Z",
+                "genres": [],
+                "genresLock": false,
+                "language": "",
+                "languageLock": false,
+                "lastModified": "2024-01-01T00:00:00Z",
+                "links": [],
+                "linksLock": false,
+                "publisher": "",
+                "publisherLock": false,
+                "readingDirection": "",
+                "readingDirectionLock": false,
+                "sharingLabels": [],
+                "sharingLabelsLock": false,
+                "status": "",
+                "statusLock": false,
+                "summary": "",
+                "summaryLock": false,
+                "tags": [],
+                "tagsLock": false,
+                "title": "",
+                "titleLock": false,
+                "titleSort": "",
+                "titleSortLock": false,
+                "totalBookCount": 0,
+                "totalBookCountLock": false
+            }
+        }
+        """));
+        return $$"""{ "content": [{{items}}] }""";
     }
 }

--- a/Services.Libraries/EventHandlers/ChapterDownloadedHandler.cs
+++ b/Services.Libraries/EventHandlers/ChapterDownloadedHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using Services.Libraries.Database;
 using Services.Libraries.Helpers;
+using Services.Manga.Database;
 
 namespace Services.Libraries.EventHandlers;
 
@@ -25,6 +26,7 @@ internal sealed class ChapterDownloadedHandler(IChannel channel, IServiceProvide
     protected override async Task<bool> HandleMessage(ChapterDownloadedEvent chapterDownloadedEvent)
     {
         LibrariesContext ctx = serviceProvider.GetRequiredService<LibrariesContext>();
+        MangaContext mangaContext = serviceProvider.GetRequiredService<MangaContext>();
         ILogger<ChapterDownloadedHandler> logger = serviceProvider.GetRequiredService<ILogger<ChapterDownloadedHandler>>();
         List<DbLibraryService> libraries = await ctx.LibraryServices.ToListAsync();
 
@@ -33,7 +35,7 @@ internal sealed class ChapterDownloadedHandler(IChannel channel, IServiceProvide
         {
             if (dbLibrary.LibraryServiceType == LibraryServiceType.Komga && dbLibrary.ToExtension() is { } extension)
             {
-                bool ok = await ProcessKomga(ctx, dbLibrary, extension, chapterDownloadedEvent, logger);
+                bool ok = await ProcessKomga(ctx, mangaContext, dbLibrary, extension, chapterDownloadedEvent, logger);
                 allOk &= ok;
             }
         }
@@ -41,7 +43,7 @@ internal sealed class ChapterDownloadedHandler(IChannel channel, IServiceProvide
         return allOk;
     }
 
-    private static async Task<bool> ProcessKomga(LibrariesContext ctx, DbLibraryService dbLibrary, Extensions.Extensions.Komga komga,
+    private static async Task<bool> ProcessKomga(LibrariesContext ctx, MangaContext mangaContext, DbLibraryService dbLibrary, Extensions.Extensions.Komga komga,
         ChapterDownloadedEvent chapterDownloadedEvent, ILogger<ChapterDownloadedHandler> logger)
     {
         if (await ctx.MangaMappings.SingleOrDefaultAsync(m => m.LibraryServiceId == dbLibrary.LibraryServiceId &&
@@ -76,6 +78,17 @@ internal sealed class ChapterDownloadedHandler(IChannel channel, IServiceProvide
             await ctx.MangaMappings.AddAsync(new DbMangaIdMapping(dbLibrary.LibraryServiceId, chapterDownloadedEvent.MangaId,
                 newSeries.Id));
             await ctx.SaveChangesAsync();
+
+            try
+            {
+                await KomgaMetadataSync.PushMetadata(mangaContext, komga, newSeries.Id, chapterDownloadedEvent.MangaId, CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e,
+                    "Failed to push metadata to newly linked Komga series {SeriesId} for manga {MangaId} on library {LibraryServiceId}",
+                    newSeries.Id, chapterDownloadedEvent.MangaId, dbLibrary.LibraryServiceId);
+            }
         }
         else
         {

--- a/Services.Libraries/EventHandlers/MangaUpdatedHandler.cs
+++ b/Services.Libraries/EventHandlers/MangaUpdatedHandler.cs
@@ -1,4 +1,3 @@
-using Common.Helpers;
 using Common.Services.Events;
 using Common.Services.Events.Events;
 using Microsoft.EntityFrameworkCore;
@@ -7,7 +6,6 @@ using RabbitMQ.Client;
 using Services.Libraries.Database;
 using Services.Libraries.Helpers;
 using Services.Manga.Database;
-using Services.Manga.Database.Helpers;
 
 namespace Services.Libraries.EventHandlers;
 
@@ -53,24 +51,6 @@ internal sealed class MangaUpdatedHandler(IChannel channel, IServiceProvider ser
         if (dbLibrary?.ToExtension() is not { } komga)
             return;
 
-        if (await mangaContext.GetManga(mangaUpdatedEvent.MangaId, CancellationToken.None) is not { } mangaMetadataEntry)
-            return;
-
-        DbMetadata metadata = mangaMetadataEntry.Metadata;
-
-        await komga.UpdateSeriesMetadata(new Extensions.Extensions.KomgaSeries(mapping.SeriesId, metadata.Series, metadata.Summary ?? ""),
-            CancellationToken.None);
-
-        if (metadata.CoverId is { } coverId)
-        {
-            if (await mangaContext.Files.FirstOrDefaultAsync(f => f.FileId == coverId) is { } file)
-            {
-                MemoryStream fileBytes = await file.LoadFile(CancellationToken.None);
-                TrangaImage image = new();
-                await fileBytes.CopyToAsync(image, CancellationToken.None);
-                image.Position = 0;
-                await komga.UpdateSeriesPoster(mapping.SeriesId, image, CancellationToken.None);
-            }
-        }
+        await KomgaMetadataSync.PushMetadata(mangaContext, komga, mapping.SeriesId, mangaUpdatedEvent.MangaId, CancellationToken.None);
     }
 }

--- a/Services.Libraries/Features/Libraries/AddKomgaEndpoint.cs
+++ b/Services.Libraries/Features/Libraries/AddKomgaEndpoint.cs
@@ -1,10 +1,14 @@
+using Common.Helpers;
 using Extensions.Data;
 using Extensions.Extensions;
 using Komga.Client.Client;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Services.Libraries.Database;
 using Services.Libraries.Helpers;
+using Services.Manga.Database;
 
 namespace Services.Libraries.Features.Libraries;
 
@@ -17,12 +21,15 @@ public abstract class AddKomgaEndpoint
     /// Add komga library extension
     /// </summary>
     /// <param name="ctx"></param>
+    /// <param name="mangaContext"></param>
     /// <param name="req">Request parameters</param>
+    /// <param name="logger"></param>
     /// <param name="ct"></param>
     /// <returns>200 OK if Komga extension added</returns>
     /// <response code="200">Komga extension added</response>
     /// <response code="400">Neither or both auth modes given, or the given credentials are invalid</response>
-    public static async Task<Results<Ok<Guid>, BadRequest<string>>> Handle(LibrariesContext ctx, [FromBody]AddKomgaLibraryRequest req, CancellationToken ct)
+    public static async Task<Results<Ok<Guid>, BadRequest<string>>> Handle(LibrariesContext ctx, MangaContext mangaContext,
+        [FromBody]AddKomgaLibraryRequest req, ILogger<AddKomgaEndpoint> logger, CancellationToken ct)
     {
         KomgaAuthResolutionResult authResult = await KomgaAuthHelper.ResolveApiKey(req.BaseUrl, req.ApiKey, req.Username, req.Password, ct);
         if (authResult.Error is { } error)
@@ -37,8 +44,45 @@ public abstract class AddKomgaEndpoint
         dbLibraryService.TrangaLibraryId = await extension.CreateTrangaLibrary(ct, req.libraryRootPath);
 
         await ctx.LibraryServices.AddAsync(dbLibraryService, ct);
+
+        await LinkExistingMangaByName(ctx, mangaContext, dbLibraryService, extension, logger, ct);
+
         await ctx.SaveChangesAsync(ct);
         return TypedResults.Ok(dbLibraryService.LibraryServiceId);
+    }
+
+    /// <summary>
+    /// Links every Tranga manga to a Komga series on a name-equality basis (the Komga series name matches
+    /// the manga's on-disk directory name), and pushes metadata for each newly created link. Runs once
+    /// when a Komga library is first connected, so pre-existing manga get linked and synced immediately
+    /// instead of waiting on their next chapter download.
+    /// </summary>
+    private static async Task LinkExistingMangaByName(LibrariesContext ctx, MangaContext mangaContext, DbLibraryService dbLibraryService,
+        Extensions.Extensions.Komga extension, ILogger<AddKomgaEndpoint> logger, CancellationToken ct)
+    {
+        KomgaSeries[] seriesList = await extension.GetSeriesList(ct);
+        List<DbMangaMetadataEntries> mangaEntries = await mangaContext.MangaMetadataEntries
+            .Where(e => e.Chosen == true)
+            .ToListAsync(ct);
+
+        foreach (DbMangaMetadataEntries entry in mangaEntries)
+        {
+            string expectedName = entry.Metadata.Series.SafeFilesystemString();
+            KomgaSeries? match = seriesList.FirstOrDefault(s => s.Name == expectedName);
+            if (match is null)
+                continue;
+
+            try
+            {
+                await ctx.MangaMappings.AddAsync(new DbMangaIdMapping(dbLibraryService.LibraryServiceId, entry.MangaId, match.Id), ct);
+                await KomgaMetadataSync.PushMetadata(mangaContext, extension, match.Id, entry.MangaId, ct);
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e, "Failed to link/push metadata for manga {MangaId} to Komga series {SeriesId} on connect",
+                    entry.MangaId, match.Id);
+            }
+        }
     }
 
     public sealed record AddKomgaLibraryRequest

--- a/Services.Libraries/Helpers/KomgaMetadataSync.cs
+++ b/Services.Libraries/Helpers/KomgaMetadataSync.cs
@@ -1,0 +1,36 @@
+using Common.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Services.Manga.Database;
+using Services.Manga.Database.Helpers;
+
+namespace Services.Libraries.Helpers;
+
+/// <summary>
+/// Pushes Tranga's chosen metadata (title, summary, cover) for a manga to a linked Komga series.
+/// Shared by every place that needs to sync metadata after a manga gets linked to a Komga series
+/// (initial connect backfill, first-chapter mapping creation, and manual metadata-source changes).
+/// </summary>
+internal static class KomgaMetadataSync
+{
+    public static async Task PushMetadata(MangaContext mangaContext, Extensions.Extensions.Komga komga, string seriesId, Guid mangaId, CancellationToken ct)
+    {
+        if (await mangaContext.GetManga(mangaId, ct) is not { } mangaMetadataEntry)
+            return;
+
+        DbMetadata metadata = mangaMetadataEntry.Metadata;
+
+        await komga.UpdateSeriesMetadata(new Extensions.Extensions.KomgaSeries(seriesId, metadata.Series, metadata.Summary ?? ""), ct);
+
+        if (metadata.CoverId is { } coverId)
+        {
+            if (await mangaContext.Files.FirstOrDefaultAsync(f => f.FileId == coverId, ct) is { } file)
+            {
+                MemoryStream fileBytes = await file.LoadFile(ct);
+                TrangaImage image = new();
+                await fileBytes.CopyToAsync(image, ct);
+                image.Position = 0;
+                await komga.UpdateSeriesPoster(seriesId, image, ct);
+            }
+        }
+    }
+}

--- a/Services.Tasks/Helpers/ChapterFileHelper.cs
+++ b/Services.Tasks/Helpers/ChapterFileHelper.cs
@@ -1,10 +1,11 @@
 using System.Text.RegularExpressions;
+using Common.Helpers;
 using Common.Settings;
 using Services.Manga.Database;
 
 namespace Services.Tasks.Helpers;
 
-public static partial class ChapterFileHelper
+public static class ChapterFileHelper
 {
     /// <summary>
     /// Creates the chapter filename for a given chapter.
@@ -55,13 +56,4 @@ public static partial class ChapterFileHelper
         "T" => chapter.Title,
         _ => throw new ArgumentOutOfRangeException(nameof(parameter), parameter, null)
     };
-
-    /// <summary>
-    /// Removes "illegal" characters
-    /// </summary>
-    /// <param name="str"></param>
-    /// <returns></returns>
-    public static string SafeFilesystemString(this string str) => SafeCharacters().Replace(str, string.Empty);
-    [GeneratedRegex(@"[^0-9a-zA-Z-._\ ]")]
-    private static partial Regex SafeCharacters();
 }

--- a/Services.Tasks/Tasks/DownloadChapterTask.cs
+++ b/Services.Tasks/Tasks/DownloadChapterTask.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using Common.Helpers;
 using Common.Services.Events;
 using Common.Services.Events.Events;
 using Common.Settings;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                             
  - Komga series were only ever linked to a manga lazily on first chapter download (`ChapterDownloadedHandler`), and metadata (title/summary/poster) was only ever pushed in reaction to a manual "choose metadata source" action (`MangaUpdatedEvent`) - so a freshly   
  connected Komga library, or a freshly linked series, could sit unsynced indefinitely.                                                                                                                                                                                  
  - `AddKomgaEndpoint` now backfills `DbMangaIdMapping` rows for existing manga on a name-equality basis (Komga series name vs. the manga's sanitized directory name) when a Komga library is first connected, and immediately pushes metadata for each newly linked     
  manga.                                                                                                                                                                                                                                                                 
  - `ChapterDownloadedHandler` now pushes metadata immediately after creating a new mapping on first chapter download, instead of waiting on a later `MangaUpdatedEvent`.                                                                                                
  - Extracted the shared metadata/poster push logic into `Services.Libraries/Helpers/KomgaMetadataSync.cs`, used by `MangaUpdatedHandler`, `ChapterDownloadedHandler`, and the new `AddKomgaEndpoint` backfill.                                                          
  - Moved `SafeFilesystemString()` from `Services.Tasks` into `Common.Helpers` so `Services.Libraries` can match Komga series names against the same sanitized name used to build download directories.                                                                  
                                                                                                                                                                                                                                                                         
  Per explicit decision during planning, the existing `ChapterDownloadedHandler` new-series discovery (poll + diff last two series lists, take the `Single()` new one) was intentionally left as-is, even though it has a latent bug (throws if 0 or >1 new series appear
  in the poll window, and the RabbitMQ handler nacks with `requeue:false` on any exception, silently dropping that event). Out of scope for this change.                                                                                                                 
                                                                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                                                                           
  - [x] `dotnet test Services.Libraries.Tests/Services.Libraries.Tests.csproj` (32/32 passing, incl. 3 new tests)                                                                                                                                                        
  - [x] `dotnet test Common.Tests/Common.Tests.csproj` (125/125 passing, incl. new `SafeFilesystemString` tests)                                                                                                                                                         
  - [x] `dotnet test Services.Tasks.Tests/Services.Tasks.Tests.csproj` (91/91 passing, confirms directory-naming behavior unchanged)                                                                                                                                     
  - [x] `dotnet test Tranga.sln` (full suite green)