### PR TITLE
Expose FLARESOLVERR_URL, AllowNSFW, DownloadLanguage through docker-c…

### DIFF
--- a/Common/Settings/EnvVars.cs
+++ b/Common/Settings/EnvVars.cs
@@ -18,5 +18,5 @@ public struct EnvVars
     public static readonly string SettingsFile = Environment.GetEnvironmentVariable("SETTINGS_FILE") ?? "settings.json";
     public static readonly int WorkersMin = Math.Max(Environment.GetEnvironmentVariable("WORKERS_MIN") is { } workersMin ? int.Parse(workersMin) : 1, 1);
     public static readonly int WorkersMax = Math.Max(Environment.GetEnvironmentVariable("WORKERS_MAX") is { } workersMax ? int.Parse(workersMax) : Math.Max(Environment.ProcessorCount / 2, 1), WorkersMin);
-    public static readonly string? FlareSolverrUrl = Environment.GetEnvironmentVariable("FLARESOLVERR_URL");
+    public static readonly string? FlareSolverrUrl = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FLARESOLVERR_URL")) ? null : Environment.GetEnvironmentVariable("FLARESOLVERR_URL");
 }

--- a/Common/Settings/Settings.cs
+++ b/Common/Settings/Settings.cs
@@ -5,10 +5,10 @@ namespace Common.Settings;
 public static class Settings
 {
     public static bool AllowNSFW { get => _allowNsfw; set => UpdateValue(ref _allowNsfw, value); }
-    private static bool _allowNsfw = bool.Parse(Environment.GetEnvironmentVariable("AllowNSFW") ?? "false");
-    
+    private static bool _allowNsfw = bool.Parse(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AllowNSFW")) ? "false" : Environment.GetEnvironmentVariable("AllowNSFW")!);
+
     public static Language DownloadLanguage { get => _downloadLanguage; set => UpdateValue(ref _downloadLanguage, value); }
-    private static Language _downloadLanguage = new (Environment.GetEnvironmentVariable("DownloadLanguage") ?? "en");
+    private static Language _downloadLanguage = new (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DownloadLanguage")) ? "en" : Environment.GetEnvironmentVariable("DownloadLanguage")!);
     
     public static string ChapterNamingScheme { get => _chapterNamingScheme; set => UpdateValue(ref _chapterNamingScheme, value); }
     private static string _chapterNamingScheme = Environment.GetEnvironmentVariable("ChapterNamingScheme") ?? "?V(Vol. %V ) Ch. %C?T( - %T)";

--- a/EnvVars.md
+++ b/EnvVars.md
@@ -2,10 +2,10 @@
 
 | ENV              | default    | behaviour                                                                                                                        |
 |------------------|------------|----------------------------------------------------------------------------------------------------------------------------------|
-| AllowNSFW        | `false`    | Allow NSFW content in search results                                                                                             |
-| DownloadLanguage | `"en"`     | Language for downloaded chapters                                                                                                 | 
+| AllowNSFW        | `false`    | Allow NSFW content in search results (docker-compose/.env key: `ALLOWNSFW`)                                                      |
+| DownloadLanguage | `"en"`     | Language for downloaded chapters (docker-compose/.env key: `DOWNLOADLANGUAGE`)                                                   | 
 | MangaDirectory   | `"Manga"`  | Host path to bind-mount for downloaded Manga (docker-compose only; Covers are stored in a managed Docker volume)                | 
-| FLARESOLVERR_URL | null       | When set, a [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) instance will handler requests that Cloudflare rejected |
+| FLARESOLVERR_URL | null       | When set, a [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) instance will handler requests that Cloudflare rejected (docker-compose/.env key: `FLARESOLVERRURL`) |
 
 ## Debug
 

--- a/Tranga.AppHost/AppHost.cs
+++ b/Tranga.AppHost/AppHost.cs
@@ -44,6 +44,10 @@ IResourceBuilder<PostgresDatabaseResource> db = postgres.AddDatabase(EnvVars.DBN
 
 IResourceBuilder<ParameterResource> rabbitUser = builder.AddParameter("RabbitMqUser");
 IResourceBuilder<ParameterResource> rabbitPassword = builder.AddParameter("RabbitMqPassword", secret: true);
+
+IResourceBuilder<ParameterResource> allowNsfw = builder.AddParameter("AllowNSFW");
+IResourceBuilder<ParameterResource> downloadLanguage = builder.AddParameter("DownloadLanguage");
+IResourceBuilder<ParameterResource> flaresolverrUrl = builder.AddParameter("FlaresolverrUrl");
 IResourceBuilder<RabbitMQServerResource> rabbitmq = builder.AddRabbitMQ("messaging", rabbitUser, rabbitPassword)
     .PublishAsDockerComposeService((resource, service) =>
     {
@@ -75,6 +79,9 @@ IResourceBuilder<ProjectResource> tasksService = builder.AddProject<Services_Tas
         context.EnvironmentVariables["RABBITMQ_PORT"] = rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
         context.EnvironmentVariables["RABBITMQ_USER"] = rabbitUser.Resource.GetValueAsync(CancellationToken.None).Result;
         context.EnvironmentVariables["RABBITMQ_PASSWORD"] = rabbitPassword.Resource.GetValueAsync(CancellationToken.None).Result;
+        context.EnvironmentVariables["AllowNSFW"] = allowNsfw.Resource;
+        context.EnvironmentVariables["DownloadLanguage"] = downloadLanguage.Resource;
+        context.EnvironmentVariables["FLARESOLVERR_URL"] = flaresolverrUrl.Resource;
     })
     .PublishAsDockerComposeService((resource, service) =>
     {
@@ -113,6 +120,9 @@ IResourceBuilder<ProjectResource> mangaService = builder.AddProject<Services_Man
         context.EnvironmentVariables["RABBITMQ_PORT"] = rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
         context.EnvironmentVariables["RABBITMQ_USER"] = rabbitUser.Resource.GetValueAsync(CancellationToken.None).Result;
         context.EnvironmentVariables["RABBITMQ_PASSWORD"] = rabbitPassword.Resource.GetValueAsync(CancellationToken.None).Result;
+        context.EnvironmentVariables["AllowNSFW"] = allowNsfw.Resource;
+        context.EnvironmentVariables["DownloadLanguage"] = downloadLanguage.Resource;
+        context.EnvironmentVariables["FLARESOLVERR_URL"] = flaresolverrUrl.Resource;
     })
     .PublishAsDockerComposeService((resource, service) =>
     {

--- a/Tranga.AppHost/appsettings.Development.json
+++ b/Tranga.AppHost/appsettings.Development.json
@@ -10,6 +10,9 @@
     "PostgresPassword": "postgres",
     "Port": 5000,
     "RabbitMqUser": "tranga",
-    "RabbitMqPassword": "tranga"
+    "RabbitMqPassword": "tranga",
+    "AllowNSFW": "false",
+    "DownloadLanguage": "en",
+    "FlaresolverrUrl": ""
   }
 }

--- a/Tranga.AppHost/appsettings.json
+++ b/Tranga.AppHost/appsettings.json
@@ -11,6 +11,9 @@
     "PostgresPassword": "postgres",
     "Port": 5000,
     "RabbitMqUser": "tranga",
-    "RabbitMqPassword": "tranga"
+    "RabbitMqPassword": "tranga",
+    "AllowNSFW": "false",
+    "DownloadLanguage": "en",
+    "FlaresolverrUrl": ""
   }
 }

--- a/Tranga.AppHost/aspire-output/.env
+++ b/Tranga.AppHost/aspire-output/.env
@@ -1,3 +1,12 @@
+# Parameter AllowNSFW
+ALLOWNSFW=false
+
+# Parameter DownloadLanguage
+DOWNLOADLANGUAGE=en
+
+# Parameter FlaresolverrUrl
+FLARESOLVERRURL=
+
 # Container image name for frontend
 FRONTEND_IMAGE=
 

--- a/Tranga.AppHost/aspire-output/docker-compose.yaml
+++ b/Tranga.AppHost/aspire-output/docker-compose.yaml
@@ -58,6 +58,9 @@ services:
       RABBITMQ_PORT: "5672"
       RABBITMQ_USER: "tranga"
       RABBITMQ_PASSWORD: "tranga"
+      AllowNSFW: "${ALLOWNSFW}"
+      DownloadLanguage: "${DOWNLOADLANGUAGE}"
+      FLARESOLVERR_URL: "${FLARESOLVERRURL}"
     expose:
       - "${SERVICES_TASKS_PORT}"
     volumes:
@@ -101,6 +104,9 @@ services:
       RABBITMQ_PORT: "5672"
       RABBITMQ_USER: "tranga"
       RABBITMQ_PASSWORD: "tranga"
+      AllowNSFW: "${ALLOWNSFW}"
+      DownloadLanguage: "${DOWNLOADLANGUAGE}"
+      FLARESOLVERR_URL: "${FLARESOLVERRURL}"
     expose:
       - "${SERVICES_MANGA_PORT}"
     volumes:


### PR DESCRIPTION
Wires the three extension-facing settings into services-tasks and services-manga (the only services that invoke search/download extensions), following the same AddParameter -> ${VAR} substitution pattern already used for Postgres/RabbitMQ credentials. Also hardens EnvVars/Settings against empty-string env values so an unset .env default doesn't crash bool.Parse or feed an empty URL into FlareSolverr's ClearanceHandler.