### PR TITLE
Sort GET /mangas alphabetically by series title

### DIFF
--- a/Services.Manga.Tests/Features/Manga/GetMangaListEndpointTests.cs
+++ b/Services.Manga.Tests/Features/Manga/GetMangaListEndpointTests.cs
@@ -25,6 +25,20 @@ public class GetMangaListEndpointTests : TrangaTest
     }
 
     [Fact]
+    public async Task GetMangaList_ReturnsMangaOrderedAlphabeticallyBySeries()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+        await TestDataBuilder.SeedMangaWithChosenMetadata(context, series: "Zeta", ct: ct);
+        await TestDataBuilder.SeedMangaWithChosenMetadata(context, series: "Alpha", ct: ct);
+        await TestDataBuilder.SeedMangaWithChosenMetadata(context, series: "Mu", ct: ct);
+
+        Results<Ok<MangaDto[]>, InternalServerError> result = await GetMangaListEndpoint.Handle(context, ct);
+
+        MangaDto[] mangas = Assert.IsType<Ok<MangaDto[]>>(result.Result).Value!;
+        Assert.Equal(["Alpha", "Mu", "Zeta"], mangas.Select(m => m.MetadataEntry!.Series));
+    }
+
+    [Fact]
     public async Task GetMangaList_ReturnsEmptyWhenNoneExist()
     {
         await using MangaContext context = MangaContextFactory.Create();

--- a/Services.Manga/Features/Manga/GetMangaListEndpoint.cs
+++ b/Services.Manga/Features/Manga/GetMangaListEndpoint.cs
@@ -21,6 +21,7 @@ internal abstract class GetMangaListEndpoint
     {
         if (await mangaContext.MangaMetadataEntries
                 .Where(s => s.Chosen == true)
+                .OrderBy(s => s.Metadata.Series)
                 .ToListAsync(ct) is not { } metadataSources)
         {
             return TypedResults.InternalServerError();


### PR DESCRIPTION
Adds OrderBy(Metadata.Series) to the manga list query so the homepage manga list renders alphabetically instead of in arbitrary DB order.