### PR TITLE
Scope Komga series linking to Tranga's library, prune stale mappings

### DIFF
--- a/Extensions.Tests/Extensions/KomgaTests.cs
+++ b/Extensions.Tests/Extensions/KomgaTests.cs
@@ -235,4 +235,22 @@ public sealed class KomgaTests : Common.Tests.TrangaTest
         Assert.Equal("Some Series", onlySeries.Name);
         Assert.Equal("Series summary", onlySeries.Summary);
     }
+
+    [Fact]
+    public async Task GetSeriesListScopedToLibrary_SendsLibraryIdFilter()
+    {
+        const string responseBody = """
+        {
+            "content": []
+        }
+        """;
+        using RecordingHttpServer server = new(HttpStatusCode.OK, responseBody);
+        KomgaExtension extension = new(server.BaseUrl, "api-key");
+
+        KomgaSeries[] series = await extension.GetSeriesList("the-tranga-library-id", ct);
+
+        Assert.Empty(series);
+        Assert.NotNull(server.LastRequest);
+        Assert.Contains("library_id=the-tranga-library-id", server.LastRequest!.Url!.Query);
+    }
 }

--- a/Extensions/Extensions/Komga.cs
+++ b/Extensions/Extensions/Komga.cs
@@ -69,6 +69,16 @@ public sealed class Komga : ILibraryExtension<KomgaSeries, KomgaBook, StringIden
         return pageSeriesDto.Content.Select(s => new KomgaSeries(s.Id, s.Name, s.Metadata.Summary)).ToArray();
     }
 
+    /// <summary>
+    /// Fetches only the series belonging to the given Komga library, so matching/linking never
+    /// considers series from other libraries on the same Komga instance.
+    /// </summary>
+    public async Task<KomgaSeries[]> GetSeriesList(StringIdentifier libraryId, CancellationToken ct)
+    {
+        PageSeriesDto pageSeriesDto = await _series.GetSeriesDeprecatedAsync(libraryId: [libraryId], unpaged: true, cancellationToken: ct);
+        return pageSeriesDto.Content.Select(s => new KomgaSeries(s.Id, s.Name, s.Metadata.Summary)).ToArray();
+    }
+
     public Task UpdateSeriesMetadata(KomgaSeries series, CancellationToken ct)
     {
         SeriesMetadataUpdateDto dto = new(title: series.Name, summary: series.Summary);

--- a/Services.Libraries.Tests/Features/Libraries/LinkLibraryMangaEndpointTests.cs
+++ b/Services.Libraries.Tests/Features/Libraries/LinkLibraryMangaEndpointTests.cs
@@ -171,6 +171,30 @@ public sealed class LinkLibraryMangaEndpointTests : TrangaTest
     }
 
     [Fact]
+    public async Task Handle_RemovesMappingWhoseSeriesNoLongerExistsInKomga()
+    {
+        using FakeKomgaServer server = new(path => (HttpStatusCode.OK, SeriesListBody()));
+
+        await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
+        DbLibraryService library = NewKomgaLibrary(server.BaseUrl);
+        await context.LibraryServices.AddAsync(library, ct);
+
+        DbManga manga = await SeedMangaWithChosenMetadata(mangaContext, "My Manga Title", ct);
+        await context.MangaMappings.AddAsync(new DbMangaIdMapping(library.LibraryServiceId, manga.MangaId, "deleted-series-id"), ct);
+        await context.SaveChangesAsync(ct);
+
+        Results<Ok<int>, NotFound, BadRequest<string>> result =
+            await LinkLibraryMangaEndpoint.Handle(context, mangaContext, library.LibraryServiceId, NullLogger<LinkLibraryMangaEndpoint>.Instance, ct);
+
+        Assert.Equal(0, Assert.IsType<Ok<int>>(result.Result).Value);
+
+        DbMangaIdMapping? mapping = await context.MangaMappings
+            .SingleOrDefaultAsync(m => m.LibraryServiceId == library.LibraryServiceId && m.MangaId == manga.MangaId, ct);
+        Assert.Null(mapping);
+    }
+
+    [Fact]
     public async Task Handle_UnknownLibrary_ReturnsNotFound()
     {
         await using LibrariesContext context = LibrariesContextFactory.Create();

--- a/Services.Libraries/EventHandlers/ChapterDownloadedHandler.cs
+++ b/Services.Libraries/EventHandlers/ChapterDownloadedHandler.cs
@@ -49,14 +49,14 @@ internal sealed class ChapterDownloadedHandler(IChannel channel, IServiceProvide
         if (await ctx.MangaMappings.SingleOrDefaultAsync(m => m.LibraryServiceId == dbLibrary.LibraryServiceId &&
                                                               m.MangaId == chapterDownloadedEvent.MangaId) is null)
         {
-            KomgaSeries[] seriesList = await komga.GetSeriesList(CancellationToken.None);
+            KomgaSeries[] seriesList = await komga.GetSeriesList(dbLibrary.TrangaLibraryId, CancellationToken.None);
             await komga.ScanLibrary(dbLibrary.TrangaLibraryId, CancellationToken.None);
 
             KomgaSeries[] newSeriesList = seriesList;
             bool foundNewSeries = false;
             for (int attempt = 0; attempt < MaxSeriesPollAttempts; attempt++)
             {
-                newSeriesList = await komga.GetSeriesList(CancellationToken.None);
+                newSeriesList = await komga.GetSeriesList(dbLibrary.TrangaLibraryId, CancellationToken.None);
                 if (newSeriesList.Length != seriesList.Length)
                 {
                     foundNewSeries = true;

--- a/Services.Libraries/Helpers/KomgaSeriesLinker.cs
+++ b/Services.Libraries/Helpers/KomgaSeriesLinker.cs
@@ -9,24 +9,34 @@ namespace Services.Libraries.Helpers;
 
 /// <summary>
 /// Links Tranga manga to Komga series on a name-equality basis (the Komga series name matches the
-/// manga's on-disk directory name), pushing metadata for each newly created link. Used both when a
-/// Komga library is first connected and when a user manually re-runs linking from the library
-/// settings page, so already-linked manga are skipped rather than re-added.
+/// manga's on-disk directory name), pushing metadata for each newly created link. Only considers
+/// series in the Komga library Tranga owns (<see cref="DbLibraryService.TrangaLibraryId"/>), and
+/// prunes mappings whose Komga series no longer exists there. Used both when a Komga library is
+/// first connected and when a user manually re-runs linking from the library settings page, so
+/// already-linked manga are skipped rather than re-added.
 /// </summary>
 internal static class KomgaSeriesLinker
 {
     public static async Task<int> LinkExistingMangaByName(LibrariesContext ctx, MangaContext mangaContext, DbLibraryService dbLibraryService,
         Extensions.Extensions.Komga extension, ILogger logger, CancellationToken ct)
     {
-        KomgaSeries[] seriesList = await extension.GetSeriesList(ct);
+        KomgaSeries[] seriesList = await extension.GetSeriesList(dbLibraryService.TrangaLibraryId, ct);
+        HashSet<string> currentSeriesIds = seriesList.Select(s => (string)s.Id).ToHashSet();
+
         List<DbMangaMetadataEntries> mangaEntries = await mangaContext.MangaMetadataEntries
             .Where(e => e.Chosen == true)
             .ToListAsync(ct);
 
-        HashSet<Guid> alreadyLinkedMangaIds = (await ctx.MangaMappings
-                .Where(m => m.LibraryServiceId == dbLibraryService.LibraryServiceId)
-                .Select(m => m.MangaId)
-                .ToListAsync(ct))
+        List<DbMangaIdMapping> existingMappings = await ctx.MangaMappings
+            .Where(m => m.LibraryServiceId == dbLibraryService.LibraryServiceId)
+            .ToListAsync(ct);
+
+        foreach (DbMangaIdMapping staleMapping in existingMappings.Where(m => !currentSeriesIds.Contains(m.SeriesId)))
+            ctx.MangaMappings.Remove(staleMapping);
+
+        HashSet<Guid> alreadyLinkedMangaIds = existingMappings
+            .Where(m => currentSeriesIds.Contains(m.SeriesId))
+            .Select(m => m.MangaId)
             .ToHashSet();
 
         int linkedCount = 0;


### PR DESCRIPTION
Series matching previously fetched every series across the whole Komga instance, so a multi-library Komga setup could link/push metadata to series outside the library Tranga owns. Scope all series lookups (linking, manual re-link, and chapter-downloaded event handling) to DbLibraryService.TrangaLibraryId, and drop mappings whose Komga series no longer exists whenever manual linking is re-run.