### PR TITLE
Fix Komga poster upload sending wrong filename/content-type

### DIFF
--- a/Extensions.Tests/Extensions/KomgaTests.cs
+++ b/Extensions.Tests/Extensions/KomgaTests.cs
@@ -19,6 +19,7 @@ public sealed class KomgaTests : Common.Tests.TrangaTest
         private readonly HttpListener _listener = new();
         public string BaseUrl { get; }
         public HttpListenerRequest? LastRequest { get; private set; }
+        public byte[]? LastRequestBody { get; private set; }
         public string? LastAuthorizationHeader { get; private set; }
         public string? LastApiKeyHeader { get; private set; }
 
@@ -46,6 +47,12 @@ public sealed class KomgaTests : Common.Tests.TrangaTest
                     LastRequest = ctx.Request;
                     LastAuthorizationHeader = ctx.Request.Headers["Authorization"];
                     LastApiKeyHeader = ctx.Request.Headers["X-API-Key"];
+
+                    using (MemoryStream bodyBuffer = new())
+                    {
+                        await ctx.Request.InputStream.CopyToAsync(bodyBuffer);
+                        LastRequestBody = bodyBuffer.ToArray();
+                    }
 
                     ctx.Response.StatusCode = (int)_statusCode;
                     if (_body is not null)
@@ -252,5 +259,25 @@ public sealed class KomgaTests : Common.Tests.TrangaTest
         Assert.Empty(series);
         Assert.NotNull(server.LastRequest);
         Assert.Contains("library_id=the-tranga-library-id", server.LastRequest!.Url!.Query);
+    }
+
+    [Fact]
+    public async Task UpdateSeriesPoster_SendsFileNameAndContentType()
+    {
+        // Regression test: the multipart file part used to be built from just the raw stream, which
+        // defaults to filename "no_name_provided" and content type "application/octet-stream" -
+        // Komga silently ignores poster uploads that don't look like a real image file.
+        using RecordingHttpServer server = new(HttpStatusCode.OK);
+        KomgaExtension extension = new(server.BaseUrl, "api-key");
+        TrangaImage image = new();
+        await image.WriteAsync("fake-image-bytes"u8.ToArray(), ct);
+        image.Position = 0;
+
+        await extension.UpdateSeriesPoster("series-1", "cover.jpg", "image/jpeg", image, ct);
+
+        Assert.NotNull(server.LastRequestBody);
+        string body = Encoding.Latin1.GetString(server.LastRequestBody);
+        Assert.Contains("filename=cover.jpg", body);
+        Assert.Contains("Content-Type: image/jpeg", body);
     }
 }

--- a/Extensions/Extensions/Komga.cs
+++ b/Extensions/Extensions/Komga.cs
@@ -85,8 +85,8 @@ public sealed class Komga : ILibraryExtension<KomgaSeries, KomgaBook, StringIden
         return _series.UpdateSeriesMetadataAsync(series.Id, dto, ct);
     }
 
-    public Task UpdateSeriesPoster(StringIdentifier seriesId, TrangaImage poster, CancellationToken ct) =>
-        _seriesPoster.AddUserUploadedSeriesThumbnailAsync(seriesId, new FileParameter(poster), selected: true, ct);
+    public Task UpdateSeriesPoster(StringIdentifier seriesId, string fileName, string contentType, TrangaImage poster, CancellationToken ct) =>
+        _seriesPoster.AddUserUploadedSeriesThumbnailAsync(seriesId, new FileParameter(fileName, contentType, poster), selected: true, ct);
 
     public Task ScanLibrary(StringIdentifier libraryId, CancellationToken ct) =>
         _librariesApi.LibraryScanAsync(libraryId, cancellationToken: ct);

--- a/Extensions/ILibraryExtension.cs
+++ b/Extensions/ILibraryExtension.cs
@@ -11,7 +11,7 @@ public interface ILibraryExtension<TSeries, TBook, TIdentifier> where TSeries : 
 
     public Task UpdateSeriesMetadata(TSeries series, CancellationToken ct);
 
-    public Task UpdateSeriesPoster(TIdentifier seriesId, TrangaImage poster, CancellationToken ct);
+    public Task UpdateSeriesPoster(TIdentifier seriesId, string fileName, string contentType, TrangaImage poster, CancellationToken ct);
 
     public Task ScanLibrary(TIdentifier libraryId, CancellationToken ct);
 }

--- a/Services.Libraries/Helpers/KomgaMetadataSync.cs
+++ b/Services.Libraries/Helpers/KomgaMetadataSync.cs
@@ -29,7 +29,7 @@ internal static class KomgaMetadataSync
                 TrangaImage image = new();
                 await fileBytes.CopyToAsync(image, ct);
                 image.Position = 0;
-                await komga.UpdateSeriesPoster(seriesId, image, ct);
+                await komga.UpdateSeriesPoster(seriesId, file.Name, file.MimeType, image, ct);
             }
         }
     }


### PR DESCRIPTION
UpdateSeriesPoster built its multipart file part from a bare stream, which defaults to filename "no_name_provided" and content type "application/octet-stream". Komga silently ignores poster uploads that don't declare a real image content type, so covers never actually synced despite the call succeeding without error. Pass the stored file's real name and MIME type through instead.