### PR TITLE
Mount Covers volume read-only into services-libraries

### DIFF
--- a/Tranga.AppHost/AppHost.cs
+++ b/Tranga.AppHost/AppHost.cs
@@ -198,6 +198,14 @@ IResourceBuilder<ProjectResource> librariesService = builder.AddProject<Services
         service.Name = "services-libraries";
         service.Networks = ["tranga"];
         service.Image = "ghcr.io/c9glax/tranga-services_libraries:external-connectors";
+        service.Volumes.Add(new Volume()
+        {
+            Name = "Covers",
+            Source = "Covers",
+            Target = "/app/Covers",
+            Type = "volume",
+            ReadOnly = true
+        });
         service.DependsOn = new()
         {
             { "tranga-pg", new ServiceDependency(){ Condition = "service_started" } },

--- a/Tranga.AppHost/aspire-output/docker-compose.yaml
+++ b/Tranga.AppHost/aspire-output/docker-compose.yaml
@@ -191,6 +191,11 @@ services:
       RABBITMQ_PASSWORD: "tranga"
     expose:
       - "${SERVICES_LIBRARIES_PORT}"
+    volumes:
+      - type: "volume"
+        target: "/app/Covers"
+        source: "Covers"
+        read_only: true
     depends_on:
       tranga-pg:
         condition: "service_started"


### PR DESCRIPTION
KomgaMetadataSync.PushMetadata reads cover files straight off disk via DbFile.LoadFile, but the Covers volume was only mounted into services-manga. In services-libraries this always threw FileLoadException (its catch-all swallowed the real FileNotFoundException), so poster syncing failed for every manga with a cover, logged as "Failed to push metadata update ... Could not load the specified file." Mount the same Covers volume read-only into services-libraries so it can read what services-manga writes.

Regenerated docker-compose.yaml via `aspire publish` per CLAUDE.md.