### PR TITLE
Show a resulting preview in the merge confirmation modal

### DIFF
--- a/Frontend/app/components/Manga/MergeConfirm.vue
+++ b/Frontend/app/components/Manga/MergeConfirm.vue
@@ -17,6 +17,15 @@
                             { label: `Keep ${targetManga.metadataEntry?.series ?? 'Target'}`, value: false },
                             { label: `Use ${sourceManga?.metadataEntry?.series ?? 'Source'}`, value: true },
                         ]" />
+
+                    <div class="flex gap-3 rounded-md border border-default p-3 mt-1">
+                        <MangaCover :file-id="previewMetadata?.coverId" no-blur class="w-16 shrink-0 rounded" />
+                        <div class="flex flex-col gap-1 min-w-0">
+                            <p class="text-xs text-dimmed uppercase tracking-wide">Preview</p>
+                            <p class="font-semibold truncate">{{ previewMetadata?.series ?? 'No metadata' }}</p>
+                            <p class="text-sm text-dimmed line-clamp-3">{{ previewMetadata?.summary }}</p>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="flex flex-col gap-2">
@@ -25,9 +34,21 @@
                         v-model="keepSourceChapters"
                         orientation="horizontal"
                         :items="[
-                            { label: `Keep ${targetManga.metadataEntry?.series ?? 'Target'}'s Chapters`, value: false },
-                            { label: `Keep ${sourceManga?.metadataEntry?.series ?? 'Source'}'s Chapters`, value: true },
+                            {
+                                label: `Keep ${targetManga.metadataEntry?.series ?? 'Target'}'s Chapters (${targetChapters?.length ?? '...'})`,
+                                value: false,
+                            },
+                            {
+                                label: `Keep ${sourceManga?.metadataEntry?.series ?? 'Source'}'s Chapters (${sourceChapters?.length ?? '...'})`,
+                                value: true,
+                            },
                         ]" />
+
+                    <p class="text-sm text-dimmed">
+                        Merged Manga will have
+                        <span class="font-semibold">{{ (keepSourceChapters ? sourceChapters : targetChapters)?.length ?? '...' }}</span>
+                        Chapters. The other Manga's Chapters are discarded.
+                    </p>
                 </div>
 
                 <div class="flex justify-end gap-2">
@@ -40,7 +61,8 @@
 </template>
 
 <script setup lang="ts">
-import type { GetMangasByMangaIdResponse, ServicesMangaManga } from '~/api/tranga';
+import { MangaCover } from '#components';
+import type { GetMangasByMangaIdChaptersResponse, GetMangasByMangaIdResponse, ServicesMangaManga } from '~/api/tranga';
 import { ApiKeys } from '~/composables/ApiKeys';
 
 const props = defineProps<{ sourceMangaId: string; targetManga: ServicesMangaManga }>();
@@ -50,9 +72,18 @@ const { data: sourceManga } = useTranga<GetMangasByMangaIdResponse>(() => `/mang
     key: ApiKeys.Manga.Manga(props.sourceMangaId),
 });
 
+const { data: targetChapters } = useTranga<GetMangasByMangaIdChaptersResponse>(() => `/mangas/${props.targetManga.mangaId}/chapters`, {
+    key: ApiKeys.Manga.Chapters.List(props.targetManga.mangaId),
+});
+const { data: sourceChapters } = useTranga<GetMangasByMangaIdChaptersResponse>(() => `/mangas/${props.sourceMangaId}/chapters`, {
+    key: ApiKeys.Manga.Chapters.List(props.sourceMangaId),
+});
+
 const keepSourceMetadata = ref(false);
 const keepSourceChapters = ref(false);
 const merging = ref(false);
+
+const previewMetadata = computed(() => (keepSourceMetadata.value ? sourceManga.value?.metadataEntry : props.targetManga.metadataEntry));
 
 const confirm = async () => {
     merging.value = true;


### PR DESCRIPTION
Title/summary/cover and chapter-count previews update live as the user toggles each option, disambiguating the case where both manga share the same displayed title.