### PR TITLE
Widen the merge confirmation modal

### DIFF
--- a/Frontend/app/components/Manga/MergeConfirm.vue
+++ b/Frontend/app/components/Manga/MergeConfirm.vue
@@ -1,5 +1,5 @@
 <template>
-    <UModal class="py-8" title="Merge Manga">
+    <UModal class="py-8" title="Merge Manga" :ui="{ content: 'max-w-2xl' }">
         <template #content>
             <div class="flex flex-col gap-6 p-6">
                 <p class="text-sm text-dimmed">


### PR DESCRIPTION
Nuxt UI's default Modal content width (max-w-md) was cutting off the title/summary preview text next to the cover thumbnail.