### PR TITLE
Add ctrl+h (go home) and ctrl+f (focus sidebar search) shortcuts

### DIFF
--- a/Frontend/app/app.vue
+++ b/Frontend/app/app.vue
@@ -2,21 +2,23 @@
     <UApp>
         <UHeader :toggle="true">
             <template #left>
-                <NuxtLink to="/">
-                    <div class="h-full flex gap-2 items-center">
-                        <img src="/blahaj.png" class="h-lh cursor-grab" alt="Blahaj" />
-                        <p
-                            style="
-                                background: linear-gradient(110deg, var(--color-pink), var(--color-blue));
-                                background-clip: text;
-                                -webkit-background-clip: text;
-                                -webkit-text-fill-color: transparent;
-                            "
-                            class="font-bold cursor-pointer text-3xl">
-                            Tranga
-                        </p>
-                    </div>
-                </NuxtLink>
+                <UTooltip text="Home" :kbds="['ctrl', 'h']">
+                    <NuxtLink to="/">
+                        <div class="h-full flex gap-2 items-center">
+                            <img src="/blahaj.png" class="h-lh cursor-grab" alt="Blahaj" />
+                            <p
+                                style="
+                                    background: linear-gradient(110deg, var(--color-pink), var(--color-blue));
+                                    background-clip: text;
+                                    -webkit-background-clip: text;
+                                    -webkit-text-fill-color: transparent;
+                                "
+                                class="font-bold cursor-pointer text-3xl">
+                                Tranga
+                            </p>
+                        </div>
+                    </NuxtLink>
+                </UTooltip>
             </template>
             <template #right>
                 <div class="flex flex-row gap-2">
@@ -48,5 +50,8 @@ const overlay = useOverlay();
 
 const searchOverlay = overlay.create(LazySearch);
 
-defineShortcuts({ ctrl_s: () => searchOverlay.open() });
+defineShortcuts({
+    ctrl_s: () => searchOverlay.open(),
+    ctrl_h: () => navigateTo('/'),
+});
 </script>

--- a/Frontend/app/components/Tranga/Page.vue
+++ b/Frontend/app/components/Tranga/Page.vue
@@ -14,11 +14,14 @@
                             </p>
                         </div>
                     </slot>
-                    <UInput
-                        v-model="searchModel"
-                        :disabled="!searchEnabled"
-                        placeholder="Search..."
-                        :icon="`i-lucide-search${searchEnabled ? '' : '-slash'}`" />
+                    <UTooltip text="Search" :kbds="['ctrl', 'f']">
+                        <UInput
+                            ref="searchInputRef"
+                            v-model="searchModel"
+                            :disabled="!searchEnabled"
+                            placeholder="Search..."
+                            :icon="`i-lucide-search${searchEnabled ? '' : '-slash'}`" />
+                    </UTooltip>
                     <UNavigationMenu :items="nItems" orientation="vertical" />
                 </slot>
             </UDashboardSidebar>
@@ -82,4 +85,13 @@ const defaultItems = computed((): NavigationMenuItem[] => {
 });
 
 const searchModel = defineModel<string>('search');
+
+const searchInputRef = useTemplateRef('searchInputRef');
+
+defineShortcuts({
+    ctrl_f: {
+        usingInput: true,
+        handler: () => searchInputRef.value?.inputRef?.focus(),
+    },
+});
 </script>


### PR DESCRIPTION
Mirrors the existing ctrl+s marking pattern via UTooltip's kbds prop on the header logo and sidebar search input.