### PR TITLE
Allow overriding the extension search term on the download-link match…

### DIFF
--- a/Frontend/app/api/tranga/index.ts
+++ b/Frontend/app/api/tranga/index.ts
@@ -195,6 +195,7 @@ export type {
     ServicesMangaMetadataExtensionsList,
     ServicesMangaPatchMangaDownloadLinkRequest,
     ServicesMangaPostMangaMergeRequest,
+    ServicesMangaPostSearchMangaDownloadLinksRequest,
     ServicesMangaPostSearchMangaRequest,
     ServicesMangaReleaseStatus,
     ServicesMangaSearchQuery,

--- a/Frontend/app/api/tranga/types.gen.ts
+++ b/Frontend/app/api/tranga/types.gen.ts
@@ -88,6 +88,8 @@ export type ServicesMangaPatchMangaDownloadLinkRequest = { matched: boolean; pri
 
 export type ServicesMangaPostMangaMergeRequest = { sourceMangaId: string; keepSourceMetadata: boolean; keepSourceChapters: boolean };
 
+export type ServicesMangaPostSearchMangaDownloadLinksRequest = { searchTerm: null | string };
+
 export type ServicesMangaPostSearchMangaRequest = { searchQuery: ServicesMangaSearchQuery; metadataExtensionIds: null | Array<string> };
 
 export type ServicesMangaReleaseStatus = 'Ongoing' | 'Complete' | 'Hiatus' | 'Cancelled';
@@ -483,7 +485,7 @@ export type PostMangasSearchResponses = {
 export type PostMangasSearchResponse = PostMangasSearchResponses[keyof PostMangasSearchResponses];
 
 export type PostMangasSearchByMangaIdDownloadLinksData = {
-    body?: never;
+    body?: null | ServicesMangaPostSearchMangaDownloadLinksRequest;
     path: { mangaId: string };
     query?: never;
     url: '/mangas/search/{mangaId}/downloadLinks';

--- a/Frontend/app/api/tranga/zod.gen.ts
+++ b/Frontend/app/api/tranga/zod.gen.ts
@@ -115,6 +115,10 @@ export const zServicesMangaPostMangaMergeRequest = z.object({
 
 export type ServicesMangaPostMangaMergeRequestZodType = z.infer<typeof zServicesMangaPostMangaMergeRequest>;
 
+export const zServicesMangaPostSearchMangaDownloadLinksRequest = z.object({ searchTerm: z.nullable(z.string()) });
+
+export type ServicesMangaPostSearchMangaDownloadLinksRequestZodType = z.infer<typeof zServicesMangaPostSearchMangaDownloadLinksRequest>;
+
 export const zServicesMangaReleaseStatus = z.enum(['Ongoing', 'Complete', 'Hiatus', 'Cancelled']);
 
 export type ServicesMangaReleaseStatusZodType = z.infer<typeof zServicesMangaReleaseStatus>;

--- a/Frontend/app/pages/manga/[mangaId]/downloadLinks.vue
+++ b/Frontend/app/pages/manga/[mangaId]/downloadLinks.vue
@@ -1,6 +1,17 @@
 <template>
     <TrangaPage :navigation-props="navigation" :page-title="{ title: 'Download-Links', icon: { name: 'i-lucide-download' } }">
         <UPageSection :ui="{ container: 'sm:py-0 lg:py-0 gap-8 sm:gap-8' }" title="Search Result">
+            <UInput
+                v-model="searchTerm"
+                placeholder="Search term (leave blank to use the manga's stored title)"
+                :loading="statusDownloadLinks === 'pending'"
+                :disabled="statusDownloadLinks === 'pending'"
+                class="w-full"
+                @keyup.enter="refreshDownloadLinks">
+                <template #trailing>
+                    <UIcon class="cursor-pointer" name="i-lucide-search" @click="refreshDownloadLinks" />
+                </template>
+            </UInput>
             <DownloadLinkList :download-links="downloadLinks" :loading="statusDownloadLinks !== 'success'" />
         </UPageSection>
     </TrangaPage>
@@ -12,10 +23,17 @@ import type { NavigationMenuProps } from '@nuxt/ui/components/NavigationMenu.vue
 
 const mangaId = useRoute().params.mangaId as string;
 
-const { data: downloadLinks, status: statusDownloadLinks } = useTranga<PostMangasSearchByMangaIdDownloadLinksResponse>(
-    () => `/mangas/search/${mangaId}/downloadLinks`,
-    { method: 'POST' },
-);
+const searchTerm = ref<string>('');
+
+const {
+    data: downloadLinks,
+    status: statusDownloadLinks,
+    refresh: refreshDownloadLinks,
+} = useTranga<PostMangasSearchByMangaIdDownloadLinksResponse>(() => `/mangas/search/${mangaId}/downloadLinks`, {
+    method: 'POST',
+    body: computed(() => (searchTerm.value ? { searchTerm: searchTerm.value } : undefined)),
+    watch: false,
+});
 
 const navigation = computed((): NavigationMenuProps => {
     return {

--- a/Services.Manga.Tests/Features/Manga/Search/PostSearchMangaDownloadLinksEndpointTests.cs
+++ b/Services.Manga.Tests/Features/Manga/Search/PostSearchMangaDownloadLinksEndpointTests.cs
@@ -20,7 +20,22 @@ public class PostSearchMangaDownloadLinksEndpointTests : TrangaTest
         await using MangaContext context = MangaContextFactory.Create();
 
         Results<Ok<MangaDownloadLinkDto[]>, NotFound, InternalServerError> result =
-            await PostSearchMangaDownloadLinksEndpoint.Handle(context, Guid.NewGuid(), ct);
+            await PostSearchMangaDownloadLinksEndpoint.Handle(context, Guid.NewGuid(), null, ct);
+
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public async Task PostSearchMangaDownloadLinks_Returns404ForUnknownManga_WithSearchTermOverride()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+
+        Results<Ok<MangaDownloadLinkDto[]>, NotFound, InternalServerError> result =
+            await PostSearchMangaDownloadLinksEndpoint.Handle(
+                context,
+                Guid.NewGuid(),
+                new PostSearchMangaDownloadLinksEndpoint.PostSearchMangaDownloadLinksRequest("some term"),
+                ct);
 
         Assert.IsType<NotFound>(result.Result);
     }

--- a/Services.Manga/Features/Manga/Search/PostSearchMangaDownloadLinksEndpoint.cs
+++ b/Services.Manga/Features/Manga/Search/PostSearchMangaDownloadLinksEndpoint.cs
@@ -1,4 +1,5 @@
 using Common;
+using Common.Datatypes;
 using Common.Helpers;
 using Common.Settings;
 using Services.Manga.Helpers;
@@ -23,16 +24,21 @@ internal abstract class PostSearchMangaDownloadLinksEndpoint
     /// </summary>
     /// <param name="mangaContext"></param>
     /// <param name="mangaId">ID of Manga to Search</param>
+    /// <param name="req"></param>
     /// <param name="ct"></param>
     /// <returns>Search result</returns>
     /// <response code="200">Search result</response>
     /// <response code="404">Manga with ID does not exist</response>
-    public static async Task<Results<Ok<MangaDownloadLink[]>, NotFound, InternalServerError>> Handle(MangaContext mangaContext, [FromRoute] Guid mangaId, CancellationToken ct)
+    public static async Task<Results<Ok<MangaDownloadLink[]>, NotFound, InternalServerError>> Handle(MangaContext mangaContext, [FromRoute] Guid mangaId, [FromBody] PostSearchMangaDownloadLinksRequest? req, CancellationToken ct)
     {
         if (await mangaContext.GetManga(mangaId, ct) is not { } source)
             return TypedResults.NotFound();
 
-        List<MangaInfo> searchResult = DownloadExtensionsCollection.SearchAll(source.ToSearchQuery(), ct);
+        SearchQuery query = req?.SearchTerm is { Length: > 0 } term
+            ? source.ToSearchQuery() with { Title = term }
+            : source.ToSearchQuery();
+
+        List<MangaInfo> searchResult = DownloadExtensionsCollection.SearchAll(query, ct);
 
         if (await mangaContext.MangaDownloadLinks.Where(m => m.MangaId == mangaId).ToListAsync(ct) is not { } existingSources)
             return TypedResults.InternalServerError();
@@ -74,8 +80,12 @@ internal abstract class PostSearchMangaDownloadLinksEndpoint
 
         return TypedResults.Ok(result.Select(r => r.ToDTO()).ToArray());
     }
-    
-    
+
+    /// <summary>
+    /// Used in <see cref="PostSearchMangaDownloadLinksEndpoint"/>
+    /// </summary>
+    /// <param name="SearchTerm">Optional free-text override for the search term. Falls back to the manga's stored title when null/empty.</param>
+    public sealed record PostSearchMangaDownloadLinksRequest(string? SearchTerm);
 
     private static async Task SaveCover(MangaContext mangaContext, MangaInfo mangaInfo, DbDownloadLink downloadLink, CancellationToken ct)
     {

--- a/Services.Manga/openapi/Services.Manga.json
+++ b/Services.Manga/openapi/Services.Manga.json
@@ -476,6 +476,22 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PostSearchMangaDownloadLinksRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1356,6 +1372,20 @@
           },
           "keepSourceChapters": {
             "type": "boolean"
+          }
+        }
+      },
+      "PostSearchMangaDownloadLinksRequest": {
+        "required": [
+          "searchTerm"
+        ],
+        "type": "object",
+        "properties": {
+          "searchTerm": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },


### PR DESCRIPTION
Manga titles stored in another language than an extension indexes under would never surface results, with no way to work around it. Lets the user type an alternate search term on the matching page instead of always searching on the manga's stored title.