### PR TITLE
Auto-link Komga on manga add and fix flaky download-time linking

### DIFF
--- a/Services.Libraries.Tests/EventHandlers/ChapterDownloadedHandlerTests.cs
+++ b/Services.Libraries.Tests/EventHandlers/ChapterDownloadedHandlerTests.cs
@@ -234,25 +234,28 @@ public sealed class ChapterDownloadedHandlerTests : TrangaTest, IDisposable
         using FakeKomgaServer server = new(path =>
         {
             if (path.Contains("/scan"))
-            {
                 return (HttpStatusCode.OK, null);
-            }
+
+            if (path.Contains("/metadata") || path.Contains("/thumbnails"))
+                return (HttpStatusCode.OK, null);
 
             seriesListCallCount++;
-            // First call (pre-scan) and the next poll attempt return no series; the one after
-            // that simulates Komga having picked up the newly scanned series.
-            return seriesListCallCount <= 2
+            // The first poll attempt returns no series; the one after that simulates Komga
+            // having picked up the newly scanned series.
+            return seriesListCallCount <= 1
                 ? (HttpStatusCode.OK, FakeKomgaServer.EmptySeriesListResponseBody)
                 : (HttpStatusCode.OK, SeriesListBody(("new-series-id", "New Series")));
         });
 
         await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
         DbLibraryService library = NewKomgaLibrary(server.BaseUrl);
         await context.LibraryServices.AddAsync(library, ct);
         await context.SaveChangesAsync(ct);
 
         Guid mangaId = Guid.NewGuid();
-        ChapterDownloadedHandler handler = CreateHandler(context);
+        await SeedMangaWithChosenMetadata(mangaContext, mangaId, "New Series", ct);
+        ChapterDownloadedHandler handler = CreateHandler(context, mangaContext);
 
         bool result = await InvokeHandleMessage(handler, NewEvent(mangaId));
 
@@ -260,6 +263,50 @@ public sealed class ChapterDownloadedHandlerTests : TrangaTest, IDisposable
         DbMangaIdMapping? mapping = context.MangaMappings.SingleOrDefault(m => m.LibraryServiceId == library.LibraryServiceId && m.MangaId == mangaId);
         Assert.NotNull(mapping);
         Assert.Equal("new-series-id", mapping.SeriesId);
+    }
+
+    [Fact]
+    public async Task HandleMessage_MultipleNewSeriesAppearInSamePollingWindow_LinksEachToCorrectManga()
+    {
+        // Regression coverage for the fragility that motivated this rewrite: the old diff-by-count
+        // approach picked the new series via `.Single(...)`, which throws if more than one new
+        // series appears within the same polling window (e.g. concurrent chapter downloads for
+        // different manga trigger overlapping scans). Name-based matching has no such assumption
+        // and correctly links each manga independently.
+        ChapterDownloadedHandler.SeriesPollInterval = TimeSpan.FromMilliseconds(1);
+
+        using FakeKomgaServer server = new(path =>
+        {
+            if (path.Contains("/scan"))
+                return (HttpStatusCode.OK, null);
+
+            if (path.Contains("/metadata") || path.Contains("/thumbnails"))
+                return (HttpStatusCode.OK, null);
+
+            return (HttpStatusCode.OK, SeriesListBody(("series-a-id", "Manga A"), ("series-b-id", "Manga B")));
+        });
+
+        await using LibrariesContext context = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
+        DbLibraryService library = NewKomgaLibrary(server.BaseUrl);
+        await context.LibraryServices.AddAsync(library, ct);
+        await context.SaveChangesAsync(ct);
+
+        Guid mangaAId = Guid.NewGuid();
+        Guid mangaBId = Guid.NewGuid();
+        await SeedMangaWithChosenMetadata(mangaContext, mangaAId, "Manga A", ct);
+        await SeedMangaWithChosenMetadata(mangaContext, mangaBId, "Manga B", ct);
+        ChapterDownloadedHandler handler = CreateHandler(context, mangaContext);
+
+        bool result = await InvokeHandleMessage(handler, NewEvent(mangaAId));
+
+        Assert.True(result);
+        DbMangaIdMapping? mappingA = context.MangaMappings.SingleOrDefault(m => m.LibraryServiceId == library.LibraryServiceId && m.MangaId == mangaAId);
+        DbMangaIdMapping? mappingB = context.MangaMappings.SingleOrDefault(m => m.LibraryServiceId == library.LibraryServiceId && m.MangaId == mangaBId);
+        Assert.NotNull(mappingA);
+        Assert.Equal("series-a-id", mappingA.SeriesId);
+        Assert.NotNull(mappingB);
+        Assert.Equal("series-b-id", mappingB.SeriesId);
     }
 
     [Fact]

--- a/Services.Libraries.Tests/EventHandlers/MangaUpdatedHandlerTests.cs
+++ b/Services.Libraries.Tests/EventHandlers/MangaUpdatedHandlerTests.cs
@@ -149,6 +149,142 @@ public sealed class MangaUpdatedHandlerTests : Common.Tests.TrangaTest
         Assert.True(result);
     }
 
+    /// <summary>
+    /// Builds a full Komga "content" SeriesDto JSON array (mirrors ChapterDownloadedHandlerTests'/
+    /// LinkLibraryMangaEndpointTests' helper of the same shape, since every
+    /// [DataMember(IsRequired = true)] field must be present).
+    /// </summary>
+    private static string SeriesListBody(params (string Id, string Name)[] series)
+    {
+        string items = string.Join(",", series.Select(s => $$"""
+        {
+            "id": "{{s.Id}}",
+            "name": "{{s.Name}}",
+            "libraryId": "komga-library-id",
+            "booksCount": 0,
+            "booksInProgressCount": 0,
+            "booksReadCount": 0,
+            "booksUnreadCount": 0,
+            "created": "2024-01-01T00:00:00Z",
+            "deleted": false,
+            "fileLastModified": "2024-01-01T00:00:00Z",
+            "lastModified": "2024-01-01T00:00:00Z",
+            "oneshot": false,
+            "url": "/some/path",
+            "booksMetadata": {
+                "authors": [],
+                "created": "2024-01-01T00:00:00Z",
+                "lastModified": "2024-01-01T00:00:00Z",
+                "summary": "",
+                "summaryNumber": "",
+                "tags": []
+            },
+            "metadata": {
+                "ageRatingLock": false,
+                "alternateTitles": [],
+                "alternateTitlesLock": false,
+                "created": "2024-01-01T00:00:00Z",
+                "genres": [],
+                "genresLock": false,
+                "language": "",
+                "languageLock": false,
+                "lastModified": "2024-01-01T00:00:00Z",
+                "links": [],
+                "linksLock": false,
+                "publisher": "",
+                "publisherLock": false,
+                "readingDirection": "",
+                "readingDirectionLock": false,
+                "sharingLabels": [],
+                "sharingLabelsLock": false,
+                "status": "",
+                "statusLock": false,
+                "summary": "",
+                "summaryLock": false,
+                "tags": [],
+                "tagsLock": false,
+                "title": "",
+                "titleLock": false,
+                "titleSort": "",
+                "titleSortLock": false,
+                "totalBookCount": 0,
+                "totalBookCountLock": false
+            }
+        }
+        """));
+        return $$"""{ "content": [{{items}}] }""";
+    }
+
+    [Fact]
+    public async Task HandleMessage_NoExistingMapping_MatchingKomgaSeriesExists_LinksAndPushesMetadataAndPoster()
+    {
+        // The gap this closes: choosing a metadata source for a manga ("adding" it) used to leave
+        // it unlinked even if a matching Komga series already existed, until the manual /link
+        // button was clicked. Now MangaUpdatedEvent (published on choosing a source) attempts the
+        // same name-match linking automatically.
+        await using LibrariesContext librariesContext = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
+
+        string tempDirectory = Path.Combine(Path.GetTempPath(), "TrangaTests", "MangaUpdatedHandlerTests", Guid.NewGuid().ToString("N"));
+        DbFile cover = await SeedCoverFile(mangaContext, tempDirectory, [1, 2, 3, 4], ct);
+        (DbManga manga, DbMetadata _) = await SeedMangaWithChosenMetadata(mangaContext, cover.FileId, ct);
+
+        ConcurrentBag<string> requestedPaths = [];
+        using FakeKomgaServer server = new(path =>
+        {
+            requestedPaths.Add(path);
+            if (path.Contains("/metadata") || path.Contains("/thumbnails"))
+                return (HttpStatusCode.OK, null);
+
+            // manga.Metadata.Series is "Updated Series Name" per SeedMangaWithChosenMetadata.
+            return (HttpStatusCode.OK, SeriesListBody(("matched-series-id", "Updated Series Name")));
+        });
+
+        DbLibraryService dbLibrary = new(LibraryServiceType.Komga, "MyLibrary", server.BaseUrl, "some-api-key") { TrangaLibraryId = "komga-library-id" };
+        await librariesContext.AddAsync(dbLibrary, ct);
+        await librariesContext.SaveChangesAsync(ct);
+
+        await using ServiceProvider serviceProvider = BuildServiceProvider(librariesContext, mangaContext);
+        MangaUpdatedHandler handler = CreateHandler(serviceProvider);
+
+        bool result = await InvokeHandleMessage(handler, new MangaUpdatedEvent(manga.MangaId));
+
+        Assert.True(result);
+        // One request for the series list (matching), one for the metadata update, one for the poster upload.
+        Assert.Equal(3, requestedPaths.Count);
+
+        DbMangaIdMapping? mapping = await librariesContext.MangaMappings
+            .SingleOrDefaultAsync(m => m.LibraryServiceId == dbLibrary.LibraryServiceId && m.MangaId == manga.MangaId, ct);
+        Assert.NotNull(mapping);
+        Assert.Equal("matched-series-id", mapping.SeriesId);
+
+        Directory.Delete(tempDirectory, recursive: true);
+    }
+
+    [Fact]
+    public async Task HandleMessage_NoExistingMapping_NoMatchingKomgaSeries_NoMappingCreatedNoError()
+    {
+        await using LibrariesContext librariesContext = LibrariesContextFactory.Create();
+        await using MangaContext mangaContext = MangaContextFactory.Create();
+
+        (DbManga manga, DbMetadata _) = await SeedMangaWithChosenMetadata(mangaContext, ct: ct);
+
+        using FakeKomgaServer server = new(HttpStatusCode.OK, SeriesListBody(("some-series-id", "Some Unrelated Series")));
+        DbLibraryService dbLibrary = new(LibraryServiceType.Komga, "MyLibrary", server.BaseUrl, "some-api-key") { TrangaLibraryId = "komga-library-id" };
+        await librariesContext.AddAsync(dbLibrary, ct);
+        await librariesContext.SaveChangesAsync(ct);
+
+        await using ServiceProvider serviceProvider = BuildServiceProvider(librariesContext, mangaContext);
+        MangaUpdatedHandler handler = CreateHandler(serviceProvider);
+
+        bool result = await InvokeHandleMessage(handler, new MangaUpdatedEvent(manga.MangaId));
+
+        Assert.True(result);
+        DbMangaIdMapping? mapping = await librariesContext.MangaMappings
+            .SingleOrDefaultAsync(m => m.LibraryServiceId == dbLibrary.LibraryServiceId && m.MangaId == manga.MangaId, ct);
+        Assert.Null(mapping);
+    }
+
     [Fact]
     public async Task HandleMessage_SkipsMappingWhenLibraryTypeUnsupported()
     {

--- a/Services.Libraries/EventHandlers/ChapterDownloadedHandler.cs
+++ b/Services.Libraries/EventHandlers/ChapterDownloadedHandler.cs
@@ -1,6 +1,5 @@
 using Common.Services.Events;
 using Common.Services.Events.Events;
-using Extensions.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,55 +45,30 @@ internal sealed class ChapterDownloadedHandler(IChannel channel, IServiceProvide
     private static async Task<bool> ProcessKomga(LibrariesContext ctx, MangaContext mangaContext, DbLibraryService dbLibrary, Extensions.Extensions.Komga komga,
         ChapterDownloadedEvent chapterDownloadedEvent, ILogger<ChapterDownloadedHandler> logger)
     {
-        if (await ctx.MangaMappings.SingleOrDefaultAsync(m => m.LibraryServiceId == dbLibrary.LibraryServiceId &&
-                                                              m.MangaId == chapterDownloadedEvent.MangaId) is null)
+        if (await ctx.MangaMappings.AnyAsync(m => m.LibraryServiceId == dbLibrary.LibraryServiceId &&
+                                                   m.MangaId == chapterDownloadedEvent.MangaId))
         {
-            KomgaSeries[] seriesList = await komga.GetSeriesList(dbLibrary.TrangaLibraryId, CancellationToken.None);
             await komga.ScanLibrary(dbLibrary.TrangaLibraryId, CancellationToken.None);
+            return true;
+        }
 
-            KomgaSeries[] newSeriesList = seriesList;
-            bool foundNewSeries = false;
-            for (int attempt = 0; attempt < MaxSeriesPollAttempts; attempt++)
-            {
-                newSeriesList = await komga.GetSeriesList(dbLibrary.TrangaLibraryId, CancellationToken.None);
-                if (newSeriesList.Length != seriesList.Length)
-                {
-                    foundNewSeries = true;
-                    break;
-                }
+        await komga.ScanLibrary(dbLibrary.TrangaLibraryId, CancellationToken.None);
 
-                await Task.Delay(SeriesPollInterval);
-            }
-
-            if (!foundNewSeries)
-            {
-                logger.LogWarning(
-                    "Timed out after {Attempts} attempts waiting for Komga library service {LibraryServiceId} to pick up the newly scanned series for manga {MangaId}. No mapping was created; the next ChapterDownloadedEvent for this manga will retry mapping discovery.",
-                    MaxSeriesPollAttempts, dbLibrary.LibraryServiceId, chapterDownloadedEvent.MangaId);
-                return true;
-            }
-
-            KomgaSeries newSeries = newSeriesList.Single(l => seriesList.All(existing => existing.Id != l.Id));
-            await ctx.MangaMappings.AddAsync(new DbMangaIdMapping(dbLibrary.LibraryServiceId, chapterDownloadedEvent.MangaId,
-                newSeries.Id));
+        for (int attempt = 0; attempt < MaxSeriesPollAttempts; attempt++)
+        {
+            await KomgaSeriesLinker.LinkExistingMangaByName(ctx, mangaContext, dbLibrary, komga, logger, CancellationToken.None);
             await ctx.SaveChangesAsync();
 
-            try
-            {
-                await KomgaMetadataSync.PushMetadata(mangaContext, komga, newSeries.Id, chapterDownloadedEvent.MangaId, CancellationToken.None);
-            }
-            catch (Exception e)
-            {
-                logger.LogWarning(e,
-                    "Failed to push metadata to newly linked Komga series {SeriesId} for manga {MangaId} on library {LibraryServiceId}",
-                    newSeries.Id, chapterDownloadedEvent.MangaId, dbLibrary.LibraryServiceId);
-            }
-        }
-        else
-        {
-            await komga.ScanLibrary(dbLibrary.TrangaLibraryId, CancellationToken.None);
+            if (await ctx.MangaMappings.AnyAsync(m => m.LibraryServiceId == dbLibrary.LibraryServiceId &&
+                                                       m.MangaId == chapterDownloadedEvent.MangaId))
+                return true;
+
+            await Task.Delay(SeriesPollInterval);
         }
 
+        logger.LogWarning(
+            "Timed out after {Attempts} attempts waiting for Komga library service {LibraryServiceId} to pick up the newly scanned series for manga {MangaId}. No mapping was created; the next ChapterDownloadedEvent for this manga will retry mapping discovery.",
+            MaxSeriesPollAttempts, dbLibrary.LibraryServiceId, chapterDownloadedEvent.MangaId);
         return true;
     }
 }

--- a/Services.Libraries/EventHandlers/MangaUpdatedHandler.cs
+++ b/Services.Libraries/EventHandlers/MangaUpdatedHandler.cs
@@ -24,7 +24,12 @@ internal sealed class MangaUpdatedHandler(IChannel channel, IServiceProvider ser
             .ToListAsync();
 
         if (mappings.Count == 0)
+        {
+            // KomgaSeriesLinker already pushes metadata for anything it newly links, so there's
+            // nothing left to do here for this manga either way.
+            await LinkToKomgaLibraries(librariesContext, mangaContext, logger);
             return true;
+        }
 
         foreach (DbMangaIdMapping mapping in mappings)
         {
@@ -52,5 +57,17 @@ internal sealed class MangaUpdatedHandler(IChannel channel, IServiceProvider ser
             return;
 
         await KomgaMetadataSync.PushMetadata(mangaContext, komga, mapping.SeriesId, mangaUpdatedEvent.MangaId, CancellationToken.None);
+    }
+
+    private static async Task LinkToKomgaLibraries(LibrariesContext librariesContext, MangaContext mangaContext, ILogger logger)
+    {
+        List<DbLibraryService> libraries = await librariesContext.LibraryServices.ToListAsync();
+        foreach (DbLibraryService dbLibrary in libraries)
+        {
+            if (dbLibrary.LibraryServiceType == LibraryServiceType.Komga && dbLibrary.ToExtension() is { } extension)
+                await KomgaSeriesLinker.LinkExistingMangaByName(librariesContext, mangaContext, dbLibrary, extension, logger, CancellationToken.None);
+        }
+
+        await librariesContext.SaveChangesAsync();
     }
 }

--- a/Services.Libraries/Helpers/KomgaSeriesLinker.cs
+++ b/Services.Libraries/Helpers/KomgaSeriesLinker.cs
@@ -11,8 +11,10 @@ namespace Services.Libraries.Helpers;
 /// Links Tranga manga to Komga series on a name-equality basis (the Komga series name matches the
 /// manga's on-disk directory name), pushing metadata for each newly created link. Only considers
 /// series in the Komga library Tranga owns (<see cref="DbLibraryService.TrangaLibraryId"/>), and
-/// prunes mappings whose Komga series no longer exists there. Used both when a Komga library is
-/// first connected and when a user manually re-runs linking from the library settings page, so
+/// prunes mappings whose Komga series no longer exists there. Used when a Komga library is first
+/// connected, when a user manually re-runs linking from the library settings page, and automatically
+/// from <see cref="EventHandlers.MangaUpdatedHandler"/> (manga added/merged/synced) and
+/// <see cref="EventHandlers.ChapterDownloadedHandler"/> (after triggering a scan) — in all cases
 /// already-linked manga are skipped rather than re-added.
 /// </summary>
 internal static class KomgaSeriesLinker


### PR DESCRIPTION
MangaUpdatedHandler now attempts KomgaSeriesLinker's name-match linking when a manga has no mapping yet, so choosing a metadata source for a manga ("adding" it) auto-links it to a matching pre-existing Komga series instead of requiring the manual /link button.

ChapterDownloadedHandler's linking was unreliable: it diffed Komga's series list by count and picked the new one via .Single(), which broke if more than one new series appeared in the same polling window (e.g. concurrent downloads) or if the scan didn't finish in time. It now polls by repeatedly running the same proven name-match linker instead.

Both paths converge on KomgaSeriesLinker.LinkExistingMangaByName, which already pushes metadata and cover to Komga for every newly linked manga.