### PR TITLE
Pin downloadlink search to the chosen manga's extension ID, not a fre…

### DIFF
--- a/Services.Manga.Tests/Helpers/SearchQueryHelperTests.cs
+++ b/Services.Manga.Tests/Helpers/SearchQueryHelperTests.cs
@@ -1,4 +1,5 @@
 using Common.Datatypes;
+using Extensions.Extensions;
 using Services.Manga.Database;
 using Services.Manga.Helpers;
 
@@ -6,18 +7,17 @@ namespace Services.Manga.Tests.Helpers;
 
 public class SearchQueryHelperTests
 {
-    [Fact]
-    public void ToSearchQuery_UsesMetadataSeriesAsTitle()
+    private static DbMangaMetadataEntries BuildEntry(Guid metadataExtension, string identifier, string series = "One Piece")
     {
         DbManga manga = new() { MangaId = Guid.NewGuid(), Monitored = true };
         DbMetadata metadata = new()
         {
             MetadataId = Guid.NewGuid(),
-            MetadataExtension = Guid.NewGuid(),
-            Identifier = "id",
-            Series = "One Piece"
+            MetadataExtension = metadataExtension,
+            Identifier = identifier,
+            Series = series
         };
-        DbMangaMetadataEntries entry = new()
+        return new()
         {
             MangaId = manga.MangaId,
             MetadataId = metadata.MetadataId,
@@ -25,9 +25,40 @@ public class SearchQueryHelperTests
             Manga = manga,
             Metadata = metadata
         };
+    }
+
+    [Fact]
+    public void ToSearchQuery_UsesMetadataSeriesAsTitle()
+    {
+        DbMangaMetadataEntries entry = BuildEntry(Guid.NewGuid(), "id");
 
         SearchQuery query = entry.ToSearchQuery();
 
         Assert.Equal("One Piece", query.Title);
+        Assert.Null(query.MangaDexSeriesId);
+        Assert.Null(query.MangaUpdatesSeriesId);
+    }
+
+    [Fact]
+    public void ToSearchQuery_MangaDexMetadata_SetsMangaDexSeriesId()
+    {
+        Guid mangaDexId = Guid.NewGuid();
+        DbMangaMetadataEntries entry = BuildEntry(new MangaDex().Identifier, mangaDexId.ToString());
+
+        SearchQuery query = entry.ToSearchQuery();
+
+        Assert.Equal(mangaDexId, query.MangaDexSeriesId);
+        Assert.Null(query.MangaUpdatesSeriesId);
+    }
+
+    [Fact]
+    public void ToSearchQuery_MangaUpdatesMetadata_SetsMangaUpdatesSeriesId()
+    {
+        DbMangaMetadataEntries entry = BuildEntry(new MangaUpdates().Identifier, "12345");
+
+        SearchQuery query = entry.ToSearchQuery();
+
+        Assert.Equal(12345L, query.MangaUpdatesSeriesId);
+        Assert.Null(query.MangaDexSeriesId);
     }
 }

--- a/Services.Manga/Helpers/SearchQueryHelper.cs
+++ b/Services.Manga/Helpers/SearchQueryHelper.cs
@@ -1,4 +1,5 @@
 using Common.Datatypes;
+using Extensions.Extensions;
 using Services.Manga.Database;
 
 namespace Services.Manga.Helpers;
@@ -8,10 +9,30 @@ namespace Services.Manga.Helpers;
 /// </summary>
 public static class SearchQueryHelper
 {
-    /// <summary>Builds a <see cref="SearchQuery"/> from a manga's metadata entry, seeded with its series title.</summary>
-    public static SearchQuery ToSearchQuery(this DbMangaMetadataEntries source) => new()
+    private static readonly Guid MangaDexExtensionId = new MangaDex().Identifier;
+    private static readonly Guid MangaUpdatesExtensionId = new MangaUpdates().Identifier;
+
+    /// <summary>
+    /// Builds a <see cref="SearchQuery"/> from a manga's metadata entry, seeded with its series title. When the
+    /// metadata came from an extension that supports exact ID lookup (MangaDex, MangaUpdates), the extension-native
+    /// series ID is included too, so a later search pins the same entry instead of re-running an independent fuzzy
+    /// title search that can drift to a different, similarly-titled manga.
+    /// </summary>
+    public static SearchQuery ToSearchQuery(this DbMangaMetadataEntries source)
     {
-        Title = source.Metadata.Series
-        //TODO Add more fields
-    };
+        DbMetadata metadata = source.Metadata;
+
+        Guid? mangaDexSeriesId = metadata.MetadataExtension == MangaDexExtensionId &&
+            Guid.TryParse(metadata.Identifier, out Guid mangaDexId) ? mangaDexId : null;
+
+        long? mangaUpdatesSeriesId = metadata.MetadataExtension == MangaUpdatesExtensionId &&
+            long.TryParse(metadata.Identifier, out long mangaUpdatesId) ? mangaUpdatesId : null;
+
+        return new()
+        {
+            Title = metadata.Series,
+            MangaDexSeriesId = mangaDexSeriesId,
+            MangaUpdatesSeriesId = mangaUpdatesSeriesId
+        };
+    }
 }


### PR DESCRIPTION
ToSearchQuery() only carried the series title, so matching download links re-ran an independent fuzzy MangaDex/MangaUpdates title search that could land on a different, similarly-titled entry than the one already chosen as metadata - surfacing wrong-language (e.g. Thai) summaries when that entry's description had no English translation. Now the extension-native series ID (MangaDex UUID, MangaUpdates numeric ID) is carried over when the metadata came from an extension that supports exact ID lookup, so the same manga is addressed deterministically instead of re-searched by title.