### PR TITLE
Set Monitored=true instead of erroring when a download-link already e…

### DIFF
--- a/Services.Manga.Tests/Features/Manga/PostMangaDownloadLinkEndpointTests.cs
+++ b/Services.Manga.Tests/Features/Manga/PostMangaDownloadLinkEndpointTests.cs
@@ -51,10 +51,11 @@ public class PostMangaDownloadLinkEndpointTests : TrangaTest
     }
 
     [Fact]
-    public async Task PostMangaDownloadLink_Returns400ForDuplicateLink()
+    public async Task PostMangaDownloadLink_DuplicateLink_SetsMonitoredAndReturnsOk()
     {
         await using MangaContext context = MangaContextFactory.Create();
-        (DbManga manga, _, _) = await TestDataBuilder.SeedMangaWithChosenMetadata(context, ct: ct);
+        (DbManga manga, _, _) = await TestDataBuilder.SeedMangaWithChosenMetadata(context, monitored: false, ct: ct);
+        Assert.False(manga.Monitored);
 
         Guid extensionId = new MangaDex().Identifier;
         Guid seriesGuid = Guid.NewGuid();
@@ -84,6 +85,8 @@ public class PostMangaDownloadLinkEndpointTests : TrangaTest
             context, manga.MangaId,
             new PostMangaDownloadLinkEndpoint.PostMangaDownloadLinkRequest(extensionId, $"https://mangadex.org/title/{seriesGuid}"), ct);
 
-        Assert.IsType<BadRequest<string>>(result.Result);
+        MangaDownloadLinkDto dto = Assert.IsType<Ok<MangaDownloadLinkDto>>(result.Result).Value!;
+        Assert.Equal(downloadLink.DownloadLinkId, dto.DownloadId);
+        Assert.True(manga.Monitored);
     }
 }

--- a/Services.Manga/Features/Manga/PostMangaDownloadLinkEndpoint.cs
+++ b/Services.Manga/Features/Manga/PostMangaDownloadLinkEndpoint.cs
@@ -22,9 +22,9 @@ internal abstract class PostMangaDownloadLinkEndpoint
     /// <param name="mangaId">ID of Manga</param>
     /// <param name="req"></param>
     /// <param name="ct"></param>
-    /// <response code="200">The Download-Link was added</response>
+    /// <response code="200">The Download-Link was added, or already existed and the Manga was set to monitored</response>
     /// <response code="404">Manga with requested ID does not exist</response>
-    /// <response code="400">The extension is unknown, the URL does not match the extension's expected shape, a Download-Link for that extension/series already exists on this Manga, or the extension could not fetch chapters for the resolved series</response>
+    /// <response code="400">The extension is unknown, the URL does not match the extension's expected shape, or the extension could not fetch chapters for the resolved series</response>
     public static async Task<Results<Ok<MangaDownloadLink>, NotFound, BadRequest<string>>> Handle(
         [FromServices] MangaContext mangaContext, [FromRoute] Guid mangaId, [FromBody] PostMangaDownloadLinkRequest req, CancellationToken ct)
     {
@@ -37,9 +37,13 @@ internal abstract class PostMangaDownloadLinkEndpoint
         if (extension.ParseIdentifierFromUrl(req.Url) is not { } identifier)
             return TypedResults.BadRequest($"That doesn't look like a {extension.Name} manga page URL.");
 
-        if (await mangaContext.MangaDownloadLinks.AnyAsync(m =>
-                m.MangaId == mangaId && m.DownloadLink.DownloadExtension == req.DownloadExtensionId && m.DownloadLink.Identifier == identifier, ct))
-            return TypedResults.BadRequest("This Manga already has a Download-Link for that extension and series.");
+        if (await mangaContext.MangaDownloadLinks.FirstOrDefaultAsync(m =>
+                m.MangaId == mangaId && m.DownloadLink.DownloadExtension == req.DownloadExtensionId && m.DownloadLink.Identifier == identifier, ct) is { } existingLink)
+        {
+            source.Manga.Monitored = true;
+            await mangaContext.SaveChangesAsync(ct);
+            return TypedResults.Ok(existingLink.ToDTO());
+        }
 
         DbDownloadLink downloadLink = new()
         {


### PR DESCRIPTION
Pasting a manga URL that was already added previously returned a 400 and did nothing. It now sets Monitored on the manga and returns the existing link, so re-adding an already-linked source is a no-op success instead of a dead-end error.