### PR TITLE
Add first-visit guided tour (search → metadata → matching → download)

### DIFF
--- a/Frontend/app/app.vue
+++ b/Frontend/app/app.vue
@@ -3,5 +3,8 @@
         <NuxtLayout>
             <NuxtPage />
         </NuxtLayout>
+        <ClientOnly>
+            <TourOverlay />
+        </ClientOnly>
     </UApp>
 </template>

--- a/Frontend/app/components/DownloadLink/ListCard.vue
+++ b/Frontend/app/components/DownloadLink/ListCard.vue
@@ -33,7 +33,7 @@
                     :to="downloadLink.url ?? undefined"
                     target="_blank"
                     :ui="{ description: 'truncate h-lh max-w-24' }" />
-                <UFieldGroup v-if="mDl">
+                <UFieldGroup v-if="mDl" class="tour-match-target">
                     <UButton v-if="!mDl.matched" variant="soft" label="Match" @click="updateMatch(true)" />
                     <UButton v-if="mDl.matched" variant="outline" label="Unmatch" @click="updateMatch(false)" />
                     <UInputNumber
@@ -56,6 +56,8 @@ const mDl = computed(() => props.downloadLink as ServicesMangaMangaDownloadLink 
 
 const { downloadExtensions } = await useDownloadExtensions();
 
+const { finishAndPersist } = useAppTour();
+
 const updateMatch = async (matched?: boolean, priority?: number) => {
     if (!mDl.value) return;
     if (matched === undefined && priority === undefined) return;
@@ -64,6 +66,7 @@ const updateMatch = async (matched?: boolean, priority?: number) => {
         priority: priority ?? mDl.value.priority,
     };
     await patchMangaDownloadLink(props.downloadLink.downloadId, mDl.value.mangaId, data);
+    if (matched) finishAndPersist();
     await navigateTo(`/manga/${mDl.value.mangaId}`);
 };
 </script>

--- a/Frontend/app/components/Tour/Overlay.vue
+++ b/Frontend/app/components/Tour/Overlay.vue
@@ -6,7 +6,6 @@
                 <p class="text-sm text-muted">{{ current?.body }}</p>
                 <div class="flex items-center justify-between gap-2">
                     <UButton variant="link" color="neutral" size="xs" label="Skip tour" @click="finishAndPersist" />
-                    <UButton v-if="index === 0" label="Let's go" size="xs" @click="next" />
                 </div>
             </div>
         </template>
@@ -15,23 +14,25 @@
 
 <script setup lang="ts">
 const { tour, finishAndPersist, startIfFirstVisit } = useAppTour();
-const { open, index, current, reference, next } = tour;
+const { open, index, current, reference } = tour;
 
 const route = useRoute();
 
+function advanceForRoute(name: string | symbol | null | undefined): void {
+    if (!open.value) return;
+    if (name === 'metadata-metadataId' && index.value < 1) {
+        tour.goTo(1);
+    } else if (name === 'manga-mangaId' && index.value < 2) {
+        tour.goTo(2);
+    }
+}
+
 onMounted(() => {
     startIfFirstVisit();
+    // Covers landing directly on a mid-flow route (deep link, or a reload
+    // mid-tour) — `watch` below only fires on subsequent route changes.
+    advanceForRoute(route.name);
 });
 
-watch(
-    () => route.name,
-    (name) => {
-        if (!open.value) return;
-        if (name === 'metadata-metadataId' && index.value < 2) {
-            tour.goTo(2);
-        } else if (name === 'manga-mangaId' && index.value < 3) {
-            tour.goTo(3);
-        }
-    },
-);
+watch(() => route.name, advanceForRoute);
 </script>

--- a/Frontend/app/components/Tour/Overlay.vue
+++ b/Frontend/app/components/Tour/Overlay.vue
@@ -1,0 +1,37 @@
+<template>
+    <UPopover :open="open" :reference="reference" :dismissible="false" :content="{ side: 'bottom' }">
+        <template #content>
+            <div class="p-4 flex flex-col gap-3 max-w-xs">
+                <p class="font-semibold">{{ current?.title }}</p>
+                <p class="text-sm text-muted">{{ current?.body }}</p>
+                <div class="flex items-center justify-between gap-2">
+                    <UButton variant="link" color="neutral" size="xs" label="Skip tour" @click="finishAndPersist" />
+                    <UButton v-if="index === 0" label="Let's go" size="xs" @click="next" />
+                </div>
+            </div>
+        </template>
+    </UPopover>
+</template>
+
+<script setup lang="ts">
+const { tour, finishAndPersist, startIfFirstVisit } = useAppTour();
+const { open, index, current, reference, next } = tour;
+
+const route = useRoute();
+
+onMounted(() => {
+    startIfFirstVisit();
+});
+
+watch(
+    () => route.name,
+    (name) => {
+        if (!open.value) return;
+        if (name === 'metadata-metadataId' && index.value < 2) {
+            tour.goTo(2);
+        } else if (name === 'manga-mangaId' && index.value < 3) {
+            tour.goTo(3);
+        }
+    },
+);
+</script>

--- a/Frontend/app/components/Tranga/Page.vue
+++ b/Frontend/app/components/Tranga/Page.vue
@@ -34,7 +34,7 @@
                             </UTooltip>
                         </template>
                         <template #right>
-                            <UDashboardSearchButton />
+                            <UDashboardSearchButton id="tour-search-button" />
                         </template>
                     </UDashboardNavbar>
                 </template>

--- a/Frontend/app/components/Tranga/Page.vue
+++ b/Frontend/app/components/Tranga/Page.vue
@@ -34,7 +34,7 @@
                             </UTooltip>
                         </template>
                         <template #right>
-                            <UDashboardSearchButton id="tour-search-button" />
+                            <UDashboardSearchButton />
                         </template>
                     </UDashboardNavbar>
                 </template>

--- a/Frontend/app/composables/useAppTour.ts
+++ b/Frontend/app/composables/useAppTour.ts
@@ -3,12 +3,7 @@ import type { TourStep, UseTourReturn } from '@nuxt/ui/composables/useTour';
 const TOUR_SEEN_KEY = 'tranga:tour:seen';
 
 export const TOUR_STEPS: TourStep[] = [
-    { title: 'Welcome to Tranga!', body: "Let's take a quick look at how to download your first manga." },
-    {
-        target: '#tour-search-button',
-        title: 'Search for a manga',
-        body: 'Click here (or press ctrl+k) and type a title to search local and remote sources.',
-    },
+    { title: 'Welcome to Tranga!', body: 'Search for a manga using the search bar up top to get started downloading your first manga.' },
     {
         target: '#tour-metadata-action',
         title: 'Pick your source',

--- a/Frontend/app/composables/useAppTour.ts
+++ b/Frontend/app/composables/useAppTour.ts
@@ -1,0 +1,80 @@
+import type { TourStep, UseTourReturn } from '@nuxt/ui/composables/useTour';
+
+const TOUR_SEEN_KEY = 'tranga:tour:seen';
+
+export const TOUR_STEPS: TourStep[] = [
+    { title: 'Welcome to Tranga!', body: "Let's take a quick look at how to download your first manga." },
+    {
+        target: '#tour-search-button',
+        title: 'Search for a manga',
+        body: 'Click here (or press ctrl+k) and type a title to search local and remote sources.',
+    },
+    {
+        target: '#tour-metadata-action',
+        title: 'Pick your source',
+        body: 'Review the metadata, then use it as the source for the manga. Once it\'s set, click "Go to Manga" to continue.',
+    },
+    { target: '.tour-match-target', title: 'Match a download-link', body: 'Found a link you like? Click "Match" to start downloading it.' },
+];
+
+function hasSeenTour(): boolean {
+    if (!import.meta.client) return true;
+    return localStorage.getItem(TOUR_SEEN_KEY) === 'true';
+}
+
+function markTourSeen(): void {
+    if (!import.meta.client) return;
+    localStorage.setItem(TOUR_SEEN_KEY, 'true');
+}
+
+let instance: UseTourReturn | undefined;
+
+/**
+ * `useTour` must never be instantiated during SSR: the resulting refs would be
+ * shared module state across every request handled by the same server process.
+ * `TourOverlay` (the only place the reactive `tour` state is actually bound to
+ * the DOM) is mounted behind `<ClientOnly>`, so this inert stub is only ever
+ * touched by SSR passes of other callers (e.g. the Settings page grabbing
+ * `replay`) and is never rendered.
+ */
+function createInertTour(): UseTourReturn {
+    return {
+        open: ref(false),
+        index: ref(0),
+        current: computed(() => undefined),
+        reference: computed(() => undefined),
+        total: computed(() => TOUR_STEPS.length),
+        hasNext: computed(() => false),
+        hasPrev: computed(() => false),
+        start: () => {},
+        next: () => {},
+        prev: () => {},
+        goTo: () => {},
+        finish: () => {},
+    };
+}
+
+function getTour(): UseTourReturn {
+    if (!import.meta.client) return createInertTour();
+    instance ??= useTour(TOUR_STEPS);
+    return instance;
+}
+
+export default function useAppTour() {
+    const tour = getTour();
+
+    const finishAndPersist = (): void => {
+        tour.finish();
+        markTourSeen();
+    };
+
+    const startIfFirstVisit = (): void => {
+        if (!hasSeenTour()) tour.start();
+    };
+
+    const replay = (): void => {
+        tour.start(0);
+    };
+
+    return { tour, hasSeenTour, finishAndPersist, startIfFirstVisit, replay };
+}

--- a/Frontend/app/pages/metadata/[metadataId].vue
+++ b/Frontend/app/pages/metadata/[metadataId].vue
@@ -37,19 +37,27 @@ const actions = (m?: ServicesMangaMetadata): ButtonProps[] | undefined => {
     if (mangaId && relatedMangaIds.value?.find((m) => m === mangaId) && !manga.value) {
         items.push({ label: 'Go to Manga', icon: 'i-lucide-book', to: `/manga/${mangaId}`, target: '_blank', variant: 'soft' });
         items.push({
+            id: 'tour-metadata-action',
             label: 'Use as Source for Manga',
             onClick: async () => await patchMangaMetadataSource(metadataId, mangaId),
             variant: 'solid',
-        });
+        } as ButtonProps);
     } else if (manga.value) {
-        items.push({ label: 'Go to Manga', icon: 'i-lucide-book', to: `/manga/${manga.value.mangaId}`, variant: 'soft' });
+        items.push({
+            id: 'tour-metadata-action',
+            label: 'Go to Manga',
+            icon: 'i-lucide-book',
+            to: `/manga/${manga.value.mangaId}`,
+            variant: 'soft',
+        } as ButtonProps);
         items.push({ label: 'Is Source', disabled: true, variant: 'outline' });
     } else if (relatedMangaIds.value?.length === 1) {
         items.push({
+            id: 'tour-metadata-action',
             label: 'Use as Source for Manga',
             onClick: async () => await patchMangaMetadataSource(metadataId, relatedMangaIds.value![0]!),
             variant: 'solid',
-        });
+        } as ButtonProps);
     }
 
     return items;

--- a/Frontend/app/pages/settings/index.vue
+++ b/Frontend/app/pages/settings/index.vue
@@ -3,8 +3,11 @@
         <UPageList>
             <UButton to="/settings/notifications" label="Notifications" icon="i-lucide-megaphone" />
             <UButton to="/settings/libraries" label="Libraries" icon="i-lucide-library" />
+            <UButton label="Replay Tour" icon="i-lucide-play" variant="outline" @click="replay" />
         </UPageList>
     </TrangaPage>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+const { replay } = useAppTour();
+</script>

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -9,7 +9,7 @@
             "dependencies": {
                 "@iconify-json/lucide": "^1.2.98",
                 "@iconify-json/simple-icons": "^1.2.74",
-                "@nuxt/ui": "^4.10.0",
+                "@nuxt/ui": "4.9.0",
                 "nuxt": "^4.4.2",
                 "openapi-typescript": "^7.13.0",
                 "tailwindcss": "^4.2.1",
@@ -2356,42 +2356,42 @@
             "license": "MIT"
         },
         "node_modules/@nuxt/ui": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.10.0.tgz",
-            "integrity": "sha512-f6eFtHZ958XIVnbpGz7OeVRjuEXdmQWgNKWBppNlh/lP790KDi8IXTZ6lndJ72lpp7hC8Wo2BbSL9zo9fwywWQ==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.9.0.tgz",
+            "integrity": "sha512-ufcG2UsX6/SMqh/oa4pIKM5AHDDK1ZWRTe6f4+Y5/xFUh1TBD25o4eb35BGFap16Uy/iIow1ih8g8h8wcw1Wcg==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/dom": "^1.8.0",
+                "@floating-ui/dom": "^1.7.6",
                 "@iconify/vue": "^5.0.1",
                 "@internationalized/date": "^3.12.2",
                 "@internationalized/number": "^3.6.7",
                 "@nuxt/fonts": "^0.14.0",
-                "@nuxt/icon": "^2.3.1",
+                "@nuxt/icon": "^2.2.3",
                 "@nuxt/kit": "^4.4.8",
                 "@nuxt/schema": "^4.4.8",
                 "@nuxtjs/color-mode": "^4.0.1",
                 "@standard-schema/spec": "^1.1.0",
-                "@tailwindcss/postcss": "^4.3.2",
-                "@tailwindcss/vite": "^4.3.2",
+                "@tailwindcss/postcss": "^4.3.1",
+                "@tailwindcss/vite": "^4.3.1",
                 "@tanstack/vue-table": "^8.21.3",
-                "@tanstack/vue-virtual": "^3.13.32",
-                "@tiptap/core": "^3.27.3",
-                "@tiptap/extension-bubble-menu": "^3.27.3",
-                "@tiptap/extension-code": "^3.27.3",
-                "@tiptap/extension-collaboration": "^3.27.3",
-                "@tiptap/extension-drag-handle": "^3.27.3",
-                "@tiptap/extension-drag-handle-vue-3": "^3.27.3",
-                "@tiptap/extension-floating-menu": "^3.27.3",
-                "@tiptap/extension-horizontal-rule": "^3.27.3",
-                "@tiptap/extension-image": "^3.27.3",
-                "@tiptap/extension-mention": "^3.27.3",
-                "@tiptap/extension-node-range": "^3.27.3",
-                "@tiptap/extension-placeholder": "^3.27.3",
-                "@tiptap/markdown": "^3.27.3",
-                "@tiptap/pm": "^3.27.3",
-                "@tiptap/starter-kit": "^3.27.3",
-                "@tiptap/suggestion": "^3.27.3",
-                "@tiptap/vue-3": "^3.27.3",
+                "@tanstack/vue-virtual": "^3.13.28",
+                "@tiptap/core": "^3.26.1",
+                "@tiptap/extension-bubble-menu": "^3.26.1",
+                "@tiptap/extension-code": "^3.26.1",
+                "@tiptap/extension-collaboration": "^3.26.1",
+                "@tiptap/extension-drag-handle": "^3.26.1",
+                "@tiptap/extension-drag-handle-vue-3": "^3.26.1",
+                "@tiptap/extension-floating-menu": "^3.26.1",
+                "@tiptap/extension-horizontal-rule": "^3.26.1",
+                "@tiptap/extension-image": "^3.26.1",
+                "@tiptap/extension-mention": "^3.26.1",
+                "@tiptap/extension-node-range": "^3.26.1",
+                "@tiptap/extension-placeholder": "^3.26.1",
+                "@tiptap/markdown": "^3.26.1",
+                "@tiptap/pm": "^3.26.1",
+                "@tiptap/starter-kit": "^3.26.1",
+                "@tiptap/suggestion": "^3.26.1",
+                "@tiptap/vue-3": "^3.26.1",
                 "@unhead/vue": "^2.1.15",
                 "@vueuse/core": "^14.3.0",
                 "@vueuse/integrations": "^14.3.0",
@@ -2406,7 +2406,7 @@
                 "embla-carousel-fade": "^8.6.0",
                 "embla-carousel-vue": "^8.6.0",
                 "embla-carousel-wheel-gestures": "^8.1.0",
-                "fuse.js": "^7.5.0",
+                "fuse.js": "^7.4.2",
                 "hookable": "^6.1.1",
                 "knitwork": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -2414,18 +2414,18 @@
                 "motion-v": "^2.3.0",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "reka-ui": "2.10.1",
+                "reka-ui": "2.9.10",
                 "scule": "^1.3.0",
                 "tailwind-merge": "^3.6.0",
                 "tailwind-variants": "^3.2.2",
-                "tailwindcss": "^4.3.2",
+                "tailwindcss": "^4.3.1",
                 "tinyglobby": "^0.2.17",
                 "ufo": "^1.6.4",
-                "unplugin": "^3.3.0",
+                "unplugin": "^3.0.0",
                 "unplugin-auto-import": "^21.0.0",
                 "unplugin-vue-components": "^32.1.0",
                 "vaul-vue": "0.4.1",
-                "vue-component-type-helpers": "^3.3.7"
+                "vue-component-type-helpers": "^3.3.5"
             },
             "bin": {
                 "nuxt-ui": "cli/index.mjs"
@@ -2455,7 +2455,6 @@
                 "@tiptap/starter-kit": "^3",
                 "@tiptap/suggestion": "^3",
                 "@tiptap/vue-3": "^3",
-                "ai": "^6 || ^7",
                 "joi": "^18.0.0",
                 "superstruct": "^2.0.0",
                 "tailwindcss": "^4.0.0",
@@ -2476,9 +2475,6 @@
                     "optional": true
                 },
                 "@nuxt/content": {
-                    "optional": true
-                },
-                "ai": {
                     "optional": true
                 },
                 "joi": {
@@ -2617,6 +2613,31 @@
             "license": "MIT",
             "bin": {
                 "giget": "dist/cli.mjs"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/reka-ui": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.9.10.tgz",
+            "integrity": "sha512-yuvZVTp4fWH2G3qk+ze/x6YYlyc2Xl1d+eMUlIYrKqzTowBKteoDoN17fitURmqSUck3mc7JbcYgp49DnGu2EQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.6.13",
+                "@floating-ui/vue": "^1.1.6",
+                "@internationalized/date": "^3.5.0",
+                "@internationalized/number": "^3.5.0",
+                "@tanstack/vue-virtual": "^3.12.0",
+                "@vueuse/core": "^14.1.0",
+                "@vueuse/shared": "^14.1.0",
+                "aria-hidden": "^1.2.4",
+                "defu": "^6.1.5",
+                "ohash": "^2.0.11"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/zernonia"
+            },
+            "peerDependencies": {
+                "vue": ">= 3.4.0"
             }
         },
         "node_modules/@nuxt/ui/node_modules/std-env": {

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -9,7 +9,7 @@
             "dependencies": {
                 "@iconify-json/lucide": "^1.2.98",
                 "@iconify-json/simple-icons": "^1.2.74",
-                "@nuxt/ui": "^4.5.1",
+                "@nuxt/ui": "^4.10.0",
                 "nuxt": "^4.4.2",
                 "openapi-typescript": "^7.13.0",
                 "tailwindcss": "^4.2.1",
@@ -1181,28 +1181,28 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+            "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.11"
+                "@floating-ui/utils": "^0.2.12"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.7.6",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+            "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/core": "^1.7.5",
-                "@floating-ui/utils": "^0.2.11"
+                "@floating-ui/core": "^1.8.0",
+                "@floating-ui/utils": "^0.2.12"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+            "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
             "license": "MIT"
         },
         "node_modules/@floating-ui/vue": {
@@ -1459,9 +1459,9 @@
             }
         },
         "node_modules/@iconify/collections": {
-            "version": "1.0.667",
-            "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.667.tgz",
-            "integrity": "sha512-VJYrtbHyi7HAlSpGv9qsVZMi94bVbrOasCmHSRn0Deu/neOmGUywqO7Ufi0gG1Cmvh/amfZeoXlgj9ErGAhEIg==",
+            "version": "1.0.723",
+            "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.723.tgz",
+            "integrity": "sha512-h9/C2f+OC/iYFwCuqPh8nFAdAbRyV0TwNUGEA2L3VI4hC89YUa6LOBMr/6LUAgcd3wMPXPnnt0Y6Ecgxqb/rIQ==",
             "license": "MIT",
             "dependencies": {
                 "@iconify/types": "*"
@@ -1474,20 +1474,20 @@
             "license": "MIT"
         },
         "node_modules/@iconify/utils": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
-            "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+            "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
             "license": "MIT",
             "dependencies": {
                 "@antfu/install-pkg": "^1.1.0",
                 "@iconify/types": "^2.0.0",
-                "mlly": "^1.8.0"
+                "import-meta-resolve": "^4.2.0"
             }
         },
         "node_modules/@iconify/vue": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@iconify/vue/-/vue-5.0.0.tgz",
-            "integrity": "sha512-C+KuEWIF5nSBrobFJhT//JS87OZ++QDORB6f2q2Wm6fl2mueSTpFBeBsveK0KW9hWiZ4mNiPjsh6Zs4jjdROSg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@iconify/vue/-/vue-5.0.1.tgz",
+            "integrity": "sha512-aumwwooJlFJ5H5qYWB6ZTAyM0C8hpfcSVLB9/a3qnH1GGvIJ+FEbpEs4s/HfErYe/M5qZeLjwmESR5fFm3lXEw==",
             "license": "MIT",
             "dependencies": {
                 "@iconify/types": "^2.0.0"
@@ -1496,22 +1496,22 @@
                 "url": "https://github.com/sponsors/cyberalien"
             },
             "peerDependencies": {
-                "vue": ">=3"
+                "vue": ">=3.0.0"
             }
         },
         "node_modules/@internationalized/date": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
-            "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+            "version": "3.12.3",
+            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
+            "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/helpers": "^0.5.0"
             }
         },
         "node_modules/@internationalized/number": {
-            "version": "3.6.5",
-            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
-            "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+            "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/helpers": "^0.5.0"
@@ -2062,25 +2062,139 @@
             }
         },
         "node_modules/@nuxt/icon": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-2.2.1.tgz",
-            "integrity": "sha512-GI840yYGuvHI0BGDQ63d6rAxGzG96jQcWrnaWIQKlyQo/7sx9PjXkSHckXUXyX1MCr9zY6U25Td6OatfY6Hklw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-2.5.0.tgz",
+            "integrity": "sha512-EBczSfd3QmAD7GoSmJ5jCPvQ5zzNaPPuWPU9DSMcBuBM10A3JIvjaMLEOEniHQRz4iVPb05cJRO/JdC60oiiwg==",
             "license": "MIT",
             "dependencies": {
-                "@iconify/collections": "^1.0.641",
+                "@iconify/collections": "^1.0.721",
                 "@iconify/types": "^2.0.0",
-                "@iconify/utils": "^3.1.0",
-                "@iconify/vue": "^5.0.0",
-                "@nuxt/devtools-kit": "^3.1.1",
-                "@nuxt/kit": "^4.2.2",
+                "@iconify/utils": "^3.1.4",
+                "@iconify/vue": "^5.0.1",
+                "@nuxt/devtools-kit": "^3.4.1",
+                "@nuxt/kit": "^4.5.2",
                 "consola": "^3.4.2",
-                "local-pkg": "^1.1.2",
-                "mlly": "^1.8.0",
+                "local-pkg": "^1.2.1",
+                "mlly": "^1.8.2",
+                "ohash": "^2.0.11",
+                "picomatch": "^4.0.5",
+                "std-env": "^4.2.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@nuxt/devtools-kit": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.1.tgz",
+            "integrity": "sha512-6ltPm2yUW8GvDdf3VJna7+flLi+ej7xRfSr+S4ovevKt/CuPf9EqYOn1jW7Kw/U1MXt/71zkn+/O2vu3G6O9Hg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nuxt/kit": "^4.5.1",
+                "execa": "^8.0.1"
+            },
+            "peerDependencies": {
+                "vite": ">=6.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@nuxt/kit": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.2.tgz",
+            "integrity": "sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.3.4",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "errx": "^0.1.2",
+                "exsolve": "^1.1.1",
+                "ignore": "^7.0.6",
+                "jiti": "^2.7.0",
+                "klona": "^2.0.6",
+                "mlly": "^1.8.2",
+                "nostics": "^1.2.0",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "std-env": "^3.10.0",
-                "tinyglobby": "^0.2.15"
+                "pkg-types": "^2.3.1",
+                "rc9": "^3.0.1",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^3.0.0",
+                "untyped": "^2.0.0",
+                "verkit": "^0.3.1"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/c12": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+            "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^5.0.0",
+                "confbox": "^0.2.4",
+                "defu": "^6.1.6",
+                "dotenv": "^17.3.1",
+                "exsolve": "^1.0.8",
+                "giget": "^3.2.0",
+                "jiti": "^2.6.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^3.0.1"
+            },
+            "peerDependencies": {
+                "magicast": "*"
+            },
+            "peerDependenciesMeta": {
+                "magicast": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/giget": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
+            "license": "MIT",
+            "bin": {
+                "giget": "dist/cli.mjs"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "license": "MIT"
+        },
+        "node_modules/@nuxt/icon/node_modules/unctx": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "magic-string": ">=0.30.21",
+                "oxc-parser": ">=0.140.0",
+                "rolldown": "^1.1.5",
+                "unplugin": "^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "magic-string": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "unplugin": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@nuxt/kit": {
@@ -2242,49 +2356,49 @@
             "license": "MIT"
         },
         "node_modules/@nuxt/ui": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.6.0.tgz",
-            "integrity": "sha512-AcoM3bljDvxd4PGfzDbY4zyyy9Zsajfagr3il1iki7G8Ji3SG6Xsgy+weug+Hyp76YM5919oc6ciJmram5bf6A==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.10.0.tgz",
+            "integrity": "sha512-f6eFtHZ958XIVnbpGz7OeVRjuEXdmQWgNKWBppNlh/lP790KDi8IXTZ6lndJ72lpp7hC8Wo2BbSL9zo9fwywWQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/dom": "^1.7.6",
-                "@iconify/vue": "^5.0.0",
-                "@internationalized/date": "^3.12.0",
-                "@internationalized/number": "^3.6.5",
+                "@floating-ui/dom": "^1.8.0",
+                "@iconify/vue": "^5.0.1",
+                "@internationalized/date": "^3.12.2",
+                "@internationalized/number": "^3.6.7",
                 "@nuxt/fonts": "^0.14.0",
-                "@nuxt/icon": "^2.2.1",
-                "@nuxt/kit": "^4.4.2",
-                "@nuxt/schema": "^4.4.2",
-                "@nuxtjs/color-mode": "^3.5.2",
+                "@nuxt/icon": "^2.3.1",
+                "@nuxt/kit": "^4.4.8",
+                "@nuxt/schema": "^4.4.8",
+                "@nuxtjs/color-mode": "^4.0.1",
                 "@standard-schema/spec": "^1.1.0",
-                "@tailwindcss/postcss": "^4.2.2",
-                "@tailwindcss/vite": "^4.2.2",
+                "@tailwindcss/postcss": "^4.3.2",
+                "@tailwindcss/vite": "^4.3.2",
                 "@tanstack/vue-table": "^8.21.3",
-                "@tanstack/vue-virtual": "^3.13.23",
-                "@tiptap/core": "^3.20.4",
-                "@tiptap/extension-bubble-menu": "^3.20.4",
-                "@tiptap/extension-code": "^3.20.4",
-                "@tiptap/extension-collaboration": "^3.20.4",
-                "@tiptap/extension-drag-handle": "^3.20.4",
-                "@tiptap/extension-drag-handle-vue-3": "^3.20.4",
-                "@tiptap/extension-floating-menu": "^3.20.4",
-                "@tiptap/extension-horizontal-rule": "^3.20.4",
-                "@tiptap/extension-image": "^3.20.4",
-                "@tiptap/extension-mention": "^3.20.4",
-                "@tiptap/extension-node-range": "^3.20.4",
-                "@tiptap/extension-placeholder": "^3.20.4",
-                "@tiptap/markdown": "^3.20.4",
-                "@tiptap/pm": "^3.20.4",
-                "@tiptap/starter-kit": "^3.20.4",
-                "@tiptap/suggestion": "^3.20.4",
-                "@tiptap/vue-3": "^3.20.4",
-                "@unhead/vue": "^2.1.12",
-                "@vueuse/core": "^14.2.1",
-                "@vueuse/integrations": "^14.2.1",
-                "@vueuse/shared": "^14.2.1",
+                "@tanstack/vue-virtual": "^3.13.32",
+                "@tiptap/core": "^3.27.3",
+                "@tiptap/extension-bubble-menu": "^3.27.3",
+                "@tiptap/extension-code": "^3.27.3",
+                "@tiptap/extension-collaboration": "^3.27.3",
+                "@tiptap/extension-drag-handle": "^3.27.3",
+                "@tiptap/extension-drag-handle-vue-3": "^3.27.3",
+                "@tiptap/extension-floating-menu": "^3.27.3",
+                "@tiptap/extension-horizontal-rule": "^3.27.3",
+                "@tiptap/extension-image": "^3.27.3",
+                "@tiptap/extension-mention": "^3.27.3",
+                "@tiptap/extension-node-range": "^3.27.3",
+                "@tiptap/extension-placeholder": "^3.27.3",
+                "@tiptap/markdown": "^3.27.3",
+                "@tiptap/pm": "^3.27.3",
+                "@tiptap/starter-kit": "^3.27.3",
+                "@tiptap/suggestion": "^3.27.3",
+                "@tiptap/vue-3": "^3.27.3",
+                "@unhead/vue": "^2.1.15",
+                "@vueuse/core": "^14.3.0",
+                "@vueuse/integrations": "^14.3.0",
+                "@vueuse/shared": "^14.3.0",
                 "colortranslator": "^5.0.0",
                 "consola": "^3.4.2",
-                "defu": "^6.1.4",
+                "defu": "^6.1.7",
                 "embla-carousel-auto-height": "^8.6.0",
                 "embla-carousel-auto-scroll": "^8.6.0",
                 "embla-carousel-autoplay": "^8.6.0",
@@ -2292,26 +2406,26 @@
                 "embla-carousel-fade": "^8.6.0",
                 "embla-carousel-vue": "^8.6.0",
                 "embla-carousel-wheel-gestures": "^8.1.0",
-                "fuse.js": "^7.1.0",
-                "hookable": "^6.1.0",
+                "fuse.js": "^7.5.0",
+                "hookable": "^6.1.1",
                 "knitwork": "^1.3.0",
                 "magic-string": "^0.30.21",
                 "mlly": "^1.8.2",
-                "motion-v": "^2.2.0",
+                "motion-v": "^2.3.0",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "reka-ui": "2.9.2",
+                "reka-ui": "2.10.1",
                 "scule": "^1.3.0",
-                "tailwind-merge": "^3.5.0",
+                "tailwind-merge": "^3.6.0",
                 "tailwind-variants": "^3.2.2",
-                "tailwindcss": "^4.2.2",
-                "tinyglobby": "^0.2.15",
-                "ufo": "^1.6.3",
-                "unplugin": "^3.0.0",
+                "tailwindcss": "^4.3.2",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unplugin": "^3.3.0",
                 "unplugin-auto-import": "^21.0.0",
-                "unplugin-vue-components": "^31.1.0",
+                "unplugin-vue-components": "^32.1.0",
                 "vaul-vue": "0.4.1",
-                "vue-component-type-helpers": "^3.2.6"
+                "vue-component-type-helpers": "^3.3.7"
             },
             "bin": {
                 "nuxt-ui": "cli/index.mjs"
@@ -2320,12 +2434,32 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "@inertiajs/vue3": "^2.0.7",
+                "@inertiajs/vue3": "^2.0.7 || ^3.0.0",
+                "@internationalized/date": "^3.0.0",
+                "@internationalized/number": "^3.0.0",
                 "@nuxt/content": "^3.0.0",
+                "@tiptap/core": "^3",
+                "@tiptap/extension-bubble-menu": "^3",
+                "@tiptap/extension-code": "^3",
+                "@tiptap/extension-collaboration": "^3",
+                "@tiptap/extension-drag-handle": "^3",
+                "@tiptap/extension-drag-handle-vue-3": "^3",
+                "@tiptap/extension-floating-menu": "^3",
+                "@tiptap/extension-horizontal-rule": "^3",
+                "@tiptap/extension-image": "^3",
+                "@tiptap/extension-mention": "^3",
+                "@tiptap/extension-node-range": "^3",
+                "@tiptap/extension-placeholder": "^3",
+                "@tiptap/markdown": "^3",
+                "@tiptap/pm": "^3",
+                "@tiptap/starter-kit": "^3",
+                "@tiptap/suggestion": "^3",
+                "@tiptap/vue-3": "^3",
+                "ai": "^6 || ^7",
                 "joi": "^18.0.0",
                 "superstruct": "^2.0.0",
                 "tailwindcss": "^4.0.0",
-                "typescript": "^5.6.3",
+                "typescript": "^5.6.3 || ^6.0.0",
                 "valibot": "^1.0.0",
                 "vue-router": "^4.5.0 || ^5.0.0",
                 "yup": "^1.7.0",
@@ -2335,7 +2469,16 @@
                 "@inertiajs/vue3": {
                     "optional": true
                 },
+                "@internationalized/date": {
+                    "optional": true
+                },
+                "@internationalized/number": {
+                    "optional": true
+                },
                 "@nuxt/content": {
+                    "optional": true
+                },
+                "ai": {
                     "optional": true
                 },
                 "joi": {
@@ -2357,6 +2500,130 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@nuxt/ui/node_modules/@nuxt/kit": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.2.tgz",
+            "integrity": "sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.3.4",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "errx": "^0.1.2",
+                "exsolve": "^1.1.1",
+                "ignore": "^7.0.6",
+                "jiti": "^2.7.0",
+                "klona": "^2.0.6",
+                "mlly": "^1.8.2",
+                "nostics": "^1.2.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "rc9": "^3.0.1",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^3.0.0",
+                "untyped": "^2.0.0",
+                "verkit": "^0.3.1"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@nuxt/kit/node_modules/unctx": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "magic-string": ">=0.30.21",
+                "oxc-parser": ">=0.140.0",
+                "rolldown": "^1.1.5",
+                "unplugin": "^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "magic-string": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "unplugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@nuxt/schema": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.5.2.tgz",
+            "integrity": "sha512-h9g1kt9O2iU9nX6HDFu9gvwtpn+8oSJX0RSTWRBnEx/Pkz+WlOHtjuS0SbkTAXw5aT1+H1GysWVwNTjJfBY/0w==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "^3.5.40",
+                "defu": "^6.1.7",
+                "nostics": "^1.2.0",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "std-env": "^4.2.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@vue/shared": {
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+            "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+            "license": "MIT"
+        },
+        "node_modules/@nuxt/ui/node_modules/c12": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+            "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^5.0.0",
+                "confbox": "^0.2.4",
+                "defu": "^6.1.6",
+                "dotenv": "^17.3.1",
+                "exsolve": "^1.0.8",
+                "giget": "^3.2.0",
+                "jiti": "^2.6.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^3.0.1"
+            },
+            "peerDependencies": {
+                "magicast": "*"
+            },
+            "peerDependenciesMeta": {
+                "magicast": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/giget": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
+            "license": "MIT",
+            "bin": {
+                "giget": "dist/cli.mjs"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "license": "MIT"
         },
         "node_modules/@nuxt/vite-builder": {
             "version": "4.4.2",
@@ -2438,94 +2705,112 @@
             "license": "MIT"
         },
         "node_modules/@nuxtjs/color-mode": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/color-mode/-/color-mode-3.5.2.tgz",
-            "integrity": "sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/color-mode/-/color-mode-4.0.1.tgz",
+            "integrity": "sha512-eiA7hWXi5zNHaYKyJFCGF6i0wFZtuvR7KDXZ6jiSvwxjCpRFwphrw0MOSmNfArTSSsT1wpW+/2H92cejeVfUlg==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "^3.13.2",
-                "pathe": "^1.1.2",
-                "pkg-types": "^1.2.1",
-                "semver": "^7.6.3"
+                "@nuxt/kit": "^4.4.6",
+                "exsolve": "^1.0.8",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "semver": "^7.8.1"
             }
         },
         "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit": {
-            "version": "3.21.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.2.tgz",
-            "integrity": "sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.2.tgz",
+            "integrity": "sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==",
             "license": "MIT",
             "dependencies": {
-                "c12": "^3.3.3",
+                "c12": "^3.3.4",
                 "consola": "^3.4.2",
-                "defu": "^6.1.4",
+                "defu": "^6.1.7",
                 "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.8",
-                "ignore": "^7.0.5",
-                "jiti": "^2.6.1",
+                "errx": "^0.1.2",
+                "exsolve": "^1.1.1",
+                "ignore": "^7.0.6",
+                "jiti": "^2.7.0",
                 "klona": "^2.0.6",
-                "knitwork": "^1.3.0",
-                "mlly": "^1.8.1",
+                "mlly": "^1.8.2",
+                "nostics": "^1.2.0",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.3.0",
-                "rc9": "^3.0.0",
+                "pkg-types": "^2.3.1",
+                "rc9": "^3.0.1",
                 "scule": "^1.3.0",
-                "semver": "^7.7.4",
-                "tinyglobby": "^0.2.15",
-                "ufo": "^1.6.3",
-                "unctx": "^2.5.0",
-                "untyped": "^2.0.0"
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^3.0.0",
+                "untyped": "^2.0.0",
+                "verkit": "^0.3.1"
             },
             "engines": {
                 "node": ">=18.12.0"
             }
         },
-        "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
-        },
-        "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit/node_modules/pkg-types": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-            "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+        "node_modules/@nuxtjs/color-mode/node_modules/c12": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+            "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
             "license": "MIT",
             "dependencies": {
-                "confbox": "^0.2.2",
-                "exsolve": "^1.0.7",
-                "pathe": "^2.0.3"
+                "chokidar": "^5.0.0",
+                "confbox": "^0.2.4",
+                "defu": "^6.1.6",
+                "dotenv": "^17.3.1",
+                "exsolve": "^1.0.8",
+                "giget": "^3.2.0",
+                "jiti": "^2.6.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^3.0.1"
+            },
+            "peerDependencies": {
+                "magicast": "*"
+            },
+            "peerDependenciesMeta": {
+                "magicast": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@nuxtjs/color-mode/node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-            "license": "MIT"
-        },
-        "node_modules/@nuxtjs/color-mode/node_modules/pkg-types": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+        "node_modules/@nuxtjs/color-mode/node_modules/giget": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
             "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.1"
+            "bin": {
+                "giget": "dist/cli.mjs"
             }
         },
-        "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/confbox": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-            "license": "MIT"
-        },
-        "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
+        "node_modules/@nuxtjs/color-mode/node_modules/unctx": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "magic-string": ">=0.30.21",
+                "oxc-parser": ">=0.140.0",
+                "rolldown": "^1.1.5",
+                "unplugin": "^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "magic-string": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "unplugin": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@oxc-minify/binding-android-arm-eabi": {
             "version": "0.117.0",
@@ -3955,12 +4240,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@remirror/core-constants": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-            "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-            "license": "MIT"
-        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-rc.2",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
@@ -4600,47 +4879,47 @@
             }
         },
         "node_modules/@tailwindcss/node": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
-            "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+            "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.5",
-                "enhanced-resolve": "^5.19.0",
-                "jiti": "^2.6.1",
+                "enhanced-resolve": "^5.24.1",
+                "jiti": "^2.7.0",
                 "lightningcss": "1.32.0",
                 "magic-string": "^0.30.21",
                 "source-map-js": "^1.2.1",
-                "tailwindcss": "4.2.2"
+                "tailwindcss": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/oxide": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
-            "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+            "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 20"
             },
             "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.2.2",
-                "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-                "@tailwindcss/oxide-darwin-x64": "4.2.2",
-                "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-                "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-                "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+                "@tailwindcss/oxide-android-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-x64": "4.3.3",
+                "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+                "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-            "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+            "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
             "cpu": [
                 "arm64"
             ],
@@ -4654,9 +4933,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
-            "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+            "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
             "cpu": [
                 "arm64"
             ],
@@ -4670,9 +4949,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-            "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+            "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
             "cpu": [
                 "x64"
             ],
@@ -4686,9 +4965,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-            "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+            "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
             "cpu": [
                 "x64"
             ],
@@ -4702,9 +4981,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-            "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+            "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
             "cpu": [
                 "arm"
             ],
@@ -4718,11 +4997,14 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-            "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+            "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -4734,11 +5016,14 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-            "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+            "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4750,11 +5035,14 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-            "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+            "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -4766,11 +5054,14 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-            "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+            "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4782,9 +5073,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-            "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+            "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
             "bundleDependencies": [
                 "@napi-rs/wasm-runtime",
                 "@emnapi/core",
@@ -4799,11 +5090,11 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.8.1",
-                "@emnapi/runtime": "^1.8.1",
-                "@emnapi/wasi-threads": "^1.1.0",
-                "@napi-rs/wasm-runtime": "^1.1.1",
-                "@tybys/wasm-util": "^0.10.1",
+                "@emnapi/core": "^1.11.1",
+                "@emnapi/runtime": "^1.11.1",
+                "@emnapi/wasi-threads": "^1.2.2",
+                "@napi-rs/wasm-runtime": "^1.1.4",
+                "@tybys/wasm-util": "^0.10.2",
                 "tslib": "^2.8.1"
             },
             "engines": {
@@ -4811,9 +5102,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-            "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+            "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4827,9 +5118,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-            "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+            "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
             "cpu": [
                 "x64"
             ],
@@ -4843,27 +5134,27 @@
             }
         },
         "node_modules/@tailwindcss/postcss": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
-            "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+            "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
             "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
-                "@tailwindcss/node": "4.2.2",
-                "@tailwindcss/oxide": "4.2.2",
-                "postcss": "^8.5.6",
-                "tailwindcss": "4.2.2"
+                "@tailwindcss/node": "4.3.3",
+                "@tailwindcss/oxide": "4.3.3",
+                "postcss": "^8.5.16",
+                "tailwindcss": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/vite": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
-            "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+            "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
             "license": "MIT",
             "dependencies": {
-                "@tailwindcss/node": "4.2.2",
-                "@tailwindcss/oxide": "4.2.2",
-                "tailwindcss": "4.2.2"
+                "@tailwindcss/node": "4.3.3",
+                "@tailwindcss/oxide": "4.3.3",
+                "tailwindcss": "4.3.3"
             },
             "peerDependencies": {
                 "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -4883,9 +5174,9 @@
             }
         },
         "node_modules/@tanstack/virtual-core": {
-            "version": "3.13.23",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
-            "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+            "version": "3.17.7",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+            "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -4912,12 +5203,12 @@
             }
         },
         "node_modules/@tanstack/vue-virtual": {
-            "version": "3.13.23",
-            "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.23.tgz",
-            "integrity": "sha512-b5jPluAR6U3eOq6GWAYSpj3ugnAIZgGR0e6aGAgyRse0Yu6MVQQ0ZWm9SArSXWtageogn6bkVD8D//c4IjW3xQ==",
+            "version": "3.13.35",
+            "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.35.tgz",
+            "integrity": "sha512-lOfSPvgPdlaH6Qy+CyIc3XpycitaSQ9GECndGpTuDiu+uDA1am+90yWXwzDSd/20ZM196ggWJLS+Qb6WjVd/OA==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/virtual-core": "3.13.23"
+                "@tanstack/virtual-core": "3.17.7"
             },
             "funding": {
                 "type": "github",
@@ -4928,48 +5219,49 @@
             }
         },
         "node_modules/@tiptap/core": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.21.0.tgz",
-            "integrity": "sha512-IfnQiuEeabDSPr1C/zHFTbnvlTf5z0DE/d/xz4C6bkL4ZBDJ3rr99h2qsaV0l8F+kbNswZMlQdM8rxNlMy95fQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.30.0.tgz",
+            "integrity": "sha512-jlR5STfcpoYxvqnWoR6dhnkB0OBTNbTWd/Jw10wx1LLCrUOK2vrM1z3rXdiVSqqoDjphEu8HX/k4q+Okt+5YGg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-blockquote": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.21.0.tgz",
-            "integrity": "sha512-JDM/RR6rM0dMCZ1UnEf7eqmN6pAdIa2llhN+E24HdTGNJCklMFhLAGE/OT8/1r7M0WWA9GVO7/PTe4EdGh6+lQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.30.0.tgz",
+            "integrity": "sha512-hDIb52yeY+IptKibIzApOTXOuJITX9F9dPSwYO3zhcxGzdWGzLjjoYyekA66lMm4fdGYkRlJWapyaG71vravLQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-bold": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.21.0.tgz",
-            "integrity": "sha512-iyEJRzG7XTCPlHwEDzUw3HnuYYCfL7lNpcCHmxcpYMrIUA8rv7EUxerIwApT6xY8hQ/07ljuJKgOyPvnJOOzuA==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.30.0.tgz",
+            "integrity": "sha512-/pDKSzd1btAIT8jWr5NGitQBe4hx4eebezT46/WCILBzf8j4+xi+dyG5fc5yebe7I4IsZlCRnmW21pLmctIHkQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-bubble-menu": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.21.0.tgz",
-            "integrity": "sha512-/fabRRhhf8i4LAx9e8xz9ppqN5KgdJk3TxMuxAD5vAWGsejvhSoPa8O8H/QwwyntXm1Vue8aQiMHsUk48b2hGQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.30.0.tgz",
+            "integrity": "sha512-53UzuEjC0OBGkip0gHBwNGFlA8d8fLaeH/K0jJEj4v4P1Xu+2wWNY3fsjEKKG6bp2sEygXIlvK+OmGoc+ObWJw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.0.0"
@@ -4979,83 +5271,83 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-bullet-list": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.21.0.tgz",
-            "integrity": "sha512-PWNF+xwxgOeXYGD88sCQLKL0eBoQqjUnZNALxBjN3Y7x4llalh42rHOp2Nt2t6UbQgqTBtBzU/uFcussTpxreQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.30.0.tgz",
+            "integrity": "sha512-NOCwi6A3zYsv2UriyJDM4Wa3Unc/ignaTsPMmHuI1CvY9o4RFrJWhNarPEwQ02vvmdDVUidGRThLZJ+qM6JGzg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.21.0"
+                "@tiptap/extension-list": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-code": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.21.0.tgz",
-            "integrity": "sha512-D7wA9jp+4X2r1f3FIoga73s6Rn4rmZY57Jes6a4rK3HY+3yHk1r057pPIZSY8Drfs97jxHQVFdfUYUomLSFYBA==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.30.0.tgz",
+            "integrity": "sha512-1KPgOXlVUQ7269u9zQU8PZYaIp6yLJj+TM6ZkuiqjGbq7UMdazO/rVofNTSMJ+jg0YqrLopEZP7DfRjkmikfnQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-code-block": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.21.0.tgz",
-            "integrity": "sha512-zrVOcOzDCjHQ8NJcC+qHmZZKiwnP/NMSb3qVJlSMN8TzuHept1MZCDa2Mbo70O6I0txo456SGuXB9sqV1vHmGg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.30.0.tgz",
+            "integrity": "sha512-m0KcCiUijaHNqTQCw9ydKRAzOrWxL0MogQu2WnTrbSrtCBwSiRvbG3ocqv5L3OfkoqnezeZCSg9JRwN+QBLP4Q==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-collaboration": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.21.0.tgz",
-            "integrity": "sha512-NNEJaKe4NK3l/yt+tQqkHYLhUQ3Qfj2eKVd7KfCriXbtRwnjRELgoynD5KwhSGiUe/wWDgt3LDMH0u+CgQ2kGw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.30.0.tgz",
+            "integrity": "sha512-EV34nkrmoMuZj9f4CzS7OEMm4tGMGhzJc+qJTp8Nh4LZnr+8x/gWEJK4CMhN7Kci3z71XF3CJ1s8Bgovyu7R9g==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0",
-                "@tiptap/y-tiptap": "^3.0.2",
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0",
+                "@tiptap/y-tiptap": "^3.0.7",
                 "yjs": "^13"
             }
         },
         "node_modules/@tiptap/extension-document": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.21.0.tgz",
-            "integrity": "sha512-7oCyzXI9ChvJQUlr23AURdfVar4OIsrYUvqdhEwo3bjcI/Q/j0KJiXfuh6ZzL5eVaINSailH53sZaGg4THQtUg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.30.0.tgz",
+            "integrity": "sha512-gSXVcISMkK9IXa2YUc0TM+lkyCWaK6KgcsIoePnCWWdUGs0wtcktz3XK9mmcVu5xntg7AR7AT9B6gvl1k+MKYA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-drag-handle": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.21.0.tgz",
-            "integrity": "sha512-1nFKSebRSf/1tDBRC0CMcXj4zW7eMhmIvNXIGEHxRa2tGll7fuxUiEHcR+fVQhG84fqTfU04HriZnoNhhLkVKg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.30.0.tgz",
+            "integrity": "sha512-jBUOCU6dghNxAAKX8LFhQLURJoA5BKseBbyq/pEHfADUSeqfExsHmPu8AeBFK+8FKh4udrJJGWZiSFCrHmvzUw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.13"
@@ -5065,46 +5357,46 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/extension-collaboration": "^3.21.0",
-                "@tiptap/extension-node-range": "^3.21.0",
-                "@tiptap/pm": "^3.21.0",
-                "@tiptap/y-tiptap": "^3.0.2"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/extension-collaboration": "3.30.0",
+                "@tiptap/extension-node-range": "3.30.0",
+                "@tiptap/pm": "3.30.0",
+                "@tiptap/y-tiptap": "^3.0.7"
             }
         },
         "node_modules/@tiptap/extension-drag-handle-vue-3": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.21.0.tgz",
-            "integrity": "sha512-V8ktaFskvUJqC+wP55aJ71kNNtLwz+6R314EDmyY9F+28K81F6Gz+W++JrZfA/+uazUdGXbJZXG+PE8To7tSRw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.30.0.tgz",
+            "integrity": "sha512-GIoyzGBnnDed5lKrMFEc0xMpxWKgELW7VX9/qKfUOvkyK+stxMm4FawYUG7GtjdhJrWd4dMsAiTdgmoxn8g0Bg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-drag-handle": "^3.21.0",
-                "@tiptap/pm": "^3.21.0",
-                "@tiptap/vue-3": "^3.21.0",
+                "@tiptap/extension-drag-handle": "3.30.0",
+                "@tiptap/pm": "3.30.0",
+                "@tiptap/vue-3": "3.30.0",
                 "vue": "^3.0.0"
             }
         },
         "node_modules/@tiptap/extension-dropcursor": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.21.0.tgz",
-            "integrity": "sha512-6fsDSVAM2iz7eElvT6iivMrGBGjIP/oPigVZ/SPm6f31phaYhz6TIOEgV/Lr2jaPIOgyK4U0cU4Yd4KUBCmhzQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.30.0.tgz",
+            "integrity": "sha512-RjTRfPH/fMaXYeRRp1etivWrH5vhrPEhEEY+34IrEXglp11svTp3heK1G2eIhppUKPRhsczWffSpUYEgEcEYsw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "^3.21.0"
+                "@tiptap/extensions": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-floating-menu": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.21.0.tgz",
-            "integrity": "sha512-n2HzTB+I/5rAl8R/1sKMv92JiY1oDK1hroXizxEKYa6dskJcAMW0CfYyPcPOZWQQEe7qoeOvQISr2ooLAKW+Mw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.30.0.tgz",
+            "integrity": "sha512-shLDHdWxFcxhJxJqdOcm0JnQP2kU1pEeokEqGyfbISgJ7iVSqyP5KabAP0TuCpJs4NN9Hw/zoAZB/LR6jXF5Mg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -5112,271 +5404,271 @@
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-gapcursor": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.21.0.tgz",
-            "integrity": "sha512-wGjgAoYBTvPAe9QYMI5px355XcNeMkaUrMY9IHbMqgqdmHcDxqooxM4H6sYVX2CRcHwXy4I8NQAoOhSYrQJDMg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.30.0.tgz",
+            "integrity": "sha512-CeRNnp1BatrpYYdt9tayp5SnAW5KYv30/Ckngrl2f6uQjcWObFkDp4klJu+7OT/DpioeOz9s3LOsSrzYLgscyg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "^3.21.0"
+                "@tiptap/extensions": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-hard-break": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.21.0.tgz",
-            "integrity": "sha512-6JFVSAOQ1qhQHi9mVcdn2/XO8YIMgYV8zjarzNUzP6Sf2waeE5BLXjlg6rIH/945sY1J+FndTojLru6gQ07a5A==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.30.0.tgz",
+            "integrity": "sha512-JzDGLfVMyvjqTPlfZ6f7+lfVu3nNg9RuhAY+N1clCr5JTzmxHsgvvpDYlkMyUvnqTbWlvW379+wtxi9BiDOpRg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-heading": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.21.0.tgz",
-            "integrity": "sha512-ji6VJmoRnDzAHYflEYEZohMHRi77UGLW1o3ua7UhI32iJ9nuYssbPNuzEeE4SvENMQwZRszad5+a+dKAa+NC7g==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.30.0.tgz",
+            "integrity": "sha512-PqUZP/dPFtBtETYXkQrybfdMRntxEY9ZQv2b+8vC0U3JCE+6IUEnJaFZgAimIyN3++ZLh3gCVvI/LfqFh3UHRQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-horizontal-rule": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.21.0.tgz",
-            "integrity": "sha512-vNBnOfFEY62CoJPGo4nonRM7RiOvhII1vhoO+WFr1GxDqCAfmEFjToflt7JT1UJdo6lMVcD+aaaAgOiuSz5p6g==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.30.0.tgz",
+            "integrity": "sha512-SD/udnQ6aAEbyi0DSf48Yh/LAPMulgvaX83MwVhzMb/qgV7eCUbJxLsqQvaaNnVFZZyl5GHbCwTbPEdEymEIRA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-image": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.21.0.tgz",
-            "integrity": "sha512-W9786a2K4LSZJMPeRLmoDulJeXOsM0ueRV2MHjTol7ikPRauROB7GUbAz9DyPAJHA2AGUfpswnGAYPO3tz5CLg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.30.0.tgz",
+            "integrity": "sha512-7KfGfbMv4Ak99fybGmpaUyhIKmfV7aZGl1YMrlj+uA2RQjzO597DGnLCEvdv2zfvwHi7WZODC8DVxJe8bKYNFw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-italic": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.21.0.tgz",
-            "integrity": "sha512-2I8oPvwyXhRn1k8lbDFIutzvhtLEjoO5mmQCNX4TnT4PdxxaSrK9+ihYg12VeqhUeO7dg1MKiFqws0HVBrwzWg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.30.0.tgz",
+            "integrity": "sha512-X/mg09T4XLG1kBXJVCONtyvzP+DOc3t0QogpYDMLOyVV5d2+p40NMIGPwfnSfVofOQynJFBCNs5rkI/eSZQz4g==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-link": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.21.0.tgz",
-            "integrity": "sha512-oMU7Yve1sbgBsaFAUc2R0GPf4d3ZPVJeMUFC6b6X9rJIvx/IhEUEn9toQcSBGfp02uWK9NdQyIFYFdWlVXH++w==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.30.0.tgz",
+            "integrity": "sha512-slfnLDFDqN4FLPBzdf1ZTM417FSxUUzfIb3Zjbe5d5r9SK6PWmf7wRCA6wb5o9BlpTPGncnKYNet+NlnBHZLWQ==",
             "license": "MIT",
             "dependencies": {
-                "linkifyjs": "^4.3.2"
+                "linkifyjs": "^4.3.3"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-list": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.21.0.tgz",
-            "integrity": "sha512-KeBlEtLrGce2d3dgL89hmwWEtREuzlW4XY5bYWpKNvCbFqvdSb3n7vkdkw32YclZmMWxAcABgW6ucCStkE0rsQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.30.0.tgz",
+            "integrity": "sha512-cunfjAWsYESK5rSVqB+xdBKX8pREuTN1wh2cR+G+OckgwQaWHB9cf3erCJ9nhvMyDVsNEGy/iJNQ6qd1CGzuoQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-list-item": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.21.0.tgz",
-            "integrity": "sha512-1ZymZmlQVbAoC4q5x3cro0v5+3I6l+BHqbhIMQLjQFlAOJfcE0pvqRzAFW7PduxUj41tXEtsYqp2NREvO9F5Fg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.30.0.tgz",
+            "integrity": "sha512-lPGsXb3wiVooxhlcqf8C5SWP4xu4xJEqhSX+0K3zTQWmubvYzc7WIePSQCKl/+PqPXyuIRyFAELKJGd9oybkKg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.21.0"
+                "@tiptap/extension-list": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-list-keymap": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.21.0.tgz",
-            "integrity": "sha512-EzrfW3ASNFPWKhR8sNOq7Kqw4hvaTAOn4dlI7chB8HIANSrlyPOUn+eKAnO6HQgsUgsbjg2GbTUrGrxcoLykUg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.30.0.tgz",
+            "integrity": "sha512-u4siME/FwDzs24tM/Z21lUQGmmkfbvMgJ+FSNk+m32lX5U0yUojviJ5sqoxaot56G2RAkhxRmJdQvKWDeLKVqA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.21.0"
+                "@tiptap/extension-list": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-mention": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.21.0.tgz",
-            "integrity": "sha512-719ByIrD1Xmby5oJE3/PQDMSrpZnpVZfGxP2+Pkw1X+YSZlgorlsOMP6G5lapZYkmcBly6P7faVhJ+6thRw0Yg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.30.0.tgz",
+            "integrity": "sha512-DAaQYFzgwrfFNyeCi3r6u5JbKEDiX959pb3NqNAwHhoBEAh6SlkFgp5U+zOOdmK7Lgq404uMNwSuNIygUA2/9g==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0",
-                "@tiptap/suggestion": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0",
+                "@tiptap/suggestion": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-node-range": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.21.0.tgz",
-            "integrity": "sha512-U9V1EiabZtpxIJFJaeCwsB1VYfqIaa6ZOzEokJhN2DV6Y0sB5JmDSB3AJemegNJv/QEE/TULM4tu3QQGuTdq3A==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.30.0.tgz",
+            "integrity": "sha512-lSF6kX0CRpT+8RKH2sTTNhrzDWENargz1PY+47kHPjaVw8LeDhahWKU8vdFUslHUAuvP2c2eVPMUE3kn6dfPug==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-ordered-list": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.21.0.tgz",
-            "integrity": "sha512-+d+0orokMfqaBfvr9tUBgGvo2ZCV+fR3JzsJTmnLBWOkhBSJN7H4pnfXPTue0qwspUwRmkLJxdIlU+J7HkMrng==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.30.0.tgz",
+            "integrity": "sha512-x4mDqfQft4szLsLCIQPKMtxdtIwZtchF1ONZMHvamy7RXOXDAa4CL5wyaNqDaRAeppI0SSL77/F0GWSqJS7aUw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "^3.21.0"
+                "@tiptap/extension-list": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-paragraph": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.21.0.tgz",
-            "integrity": "sha512-cMPG/jCoZ9NmLZ5ctFziILaxJGfDtMTb5OLBhifMFZeMVwF1pEJIygDEfnX/HSruv507weZSQG4pERO2tRszMg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.30.0.tgz",
+            "integrity": "sha512-xfGv8ZRYncPCQyKViTLAA52n9wbb1CnjxMezKbQVmckOMWroRxtT+4zmbpOslnR0cuNHIYAWMZ25MM+wxAQpsw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-placeholder": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.21.0.tgz",
-            "integrity": "sha512-fs+cQqMh1d1naV6OgOhP/0qbRJwtw8DpQMj3/oqGKbaRRKIeecEaZPXYRd7MYa4e9K0Cfk5Bm0MNs9lwu/BYsw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.30.0.tgz",
+            "integrity": "sha512-X0UviJeJREXzOerehTlmYmq7WWrA+c4PNjXFqje3r2MR4Vp9GN9lQweTfo9FHjfA7pv7ps1RHN3fuXspk5u6DA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "^3.21.0"
+                "@tiptap/extensions": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-strike": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.21.0.tgz",
-            "integrity": "sha512-easnVaN11Wl+5fOtfvzJ10J762S9TRXZaMj5rLBGavgf82DCYHqhGhBqpLQrJ41r4nPABGlYvTRoxfvBLB74Lg==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.30.0.tgz",
+            "integrity": "sha512-sn2VbcVzgW/w0gWQHhcTiIgnkai9vjejXFHwlNgnnvcNd1zZuGCJegWJDzC6Ze8XupxRwKIkgL6eSi1d4n65ow==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-text": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.21.0.tgz",
-            "integrity": "sha512-Zx8QdB8a5iBuE4uO21c3BjmpBfaJEr2Jd1QFnsdgx11fm6P7dGgZaGko1FaINhfOPRGTN6O/kiF02cDMdOHa/w==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.30.0.tgz",
+            "integrity": "sha512-NjsZzbuCkDth/XIpXQbcdoDpXQarQlISBARdwVEEXq2Cv8YEJRERblO8PHUdaP7AxuxPru5ZfgbnAkbopy/fwQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-underline": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.21.0.tgz",
-            "integrity": "sha512-gGmBEymbWnr8AIS8bI/bPw5rcwo7wAFcBw/TsLd1nAanu1dDqSRNDBrit3m02Ru+D88u2SfNvmbOPI1pz+1f5w==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.30.0.tgz",
+            "integrity": "sha512-EJ7NF3CP96gJVmdaXUJ9GaaFKpC92flftT6/PtINK4oCBPYbyWRI8nOdeBPijm12yXGbzcPS3oyIjc2FIzkdHA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extensions": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.21.0.tgz",
-            "integrity": "sha512-MN1uh5PmHT1F2BNsbc21MIS0AMFFA73oODlp/4ckpBR4o5AxRwV+8f43Cd52UL4MgMkKj/A+QfZ7iK9IDb0h5A==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.30.0.tgz",
+            "integrity": "sha512-dCevnLGpISgrMqnEse3BeZPpaPtYBdIWONIiVSl4ODDCMUthcs8QqM5qi192f0fT+jnYikD7UP3zn+hdCFOtaw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/markdown": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.21.0.tgz",
-            "integrity": "sha512-VhnHhB9LeEfB2xnbNZUV2itK0ae4iERbr+a4/ZrlZB9auPtggW4fIob/bQGOaeU+GZtk1xDLyKUDyKEEwgTXMw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.30.0.tgz",
+            "integrity": "sha512-aLNF21OTvnVHn1GksuHilmmll/19GxAvPyd25Xp+FXM3yHGx4CCgVqr+5HfApfoBwZm/73CtCGF6YuVlfvA+qw==",
             "license": "MIT",
             "dependencies": {
                 "marked": "^17.0.1"
@@ -5386,34 +5678,29 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/pm": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.21.0.tgz",
-            "integrity": "sha512-I3sNo7oMMsR6FFz1ecvPb9uCF0VQuS2WV67j8Io2M7DJicRWCE/GM5DaiYjTeWBbnByk6BuG0txoJATAqPVliQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.30.0.tgz",
+            "integrity": "sha512-0if2mMq/9nZ/IOiuuyvo36OEz/fhwFJiHNy49+NywUkkKVSsa6S7Pcsxb03RnKzW648EanOjE5oqTd4jCkgRKg==",
             "license": "MIT",
             "dependencies": {
-                "prosemirror-changeset": "^2.3.0",
-                "prosemirror-collab": "^1.3.1",
-                "prosemirror-commands": "^1.6.2",
-                "prosemirror-dropcursor": "^1.8.1",
-                "prosemirror-gapcursor": "^1.3.2",
-                "prosemirror-history": "^1.4.1",
-                "prosemirror-inputrules": "^1.4.0",
-                "prosemirror-keymap": "^1.2.2",
-                "prosemirror-markdown": "^1.13.1",
-                "prosemirror-menu": "^1.2.4",
-                "prosemirror-model": "^1.24.1",
-                "prosemirror-schema-basic": "^1.2.3",
-                "prosemirror-schema-list": "^1.5.0",
-                "prosemirror-state": "^1.4.3",
-                "prosemirror-tables": "^1.6.4",
-                "prosemirror-trailing-node": "^3.0.0",
-                "prosemirror-transform": "^1.10.2",
-                "prosemirror-view": "^1.38.1"
+                "prosemirror-changeset": "^2.4.1",
+                "prosemirror-commands": "^1.7.1",
+                "prosemirror-dropcursor": "^1.8.2",
+                "prosemirror-gapcursor": "^1.4.1",
+                "prosemirror-history": "^1.5.0",
+                "prosemirror-inputrules": "^1.5.1",
+                "prosemirror-keymap": "^1.2.3",
+                "prosemirror-model": "^1.25.11",
+                "prosemirror-schema-list": "^1.5.1",
+                "prosemirror-state": "^1.4.4",
+                "prosemirror-tables": "^1.8.5",
+                "prosemirror-transform": "^1.12.0",
+                "prosemirror-view": "^1.41.9"
             },
             "funding": {
                 "type": "github",
@@ -5421,35 +5708,35 @@
             }
         },
         "node_modules/@tiptap/starter-kit": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.21.0.tgz",
-            "integrity": "sha512-w7fWxglDtqXFBgRYH+LforJyUboSAQllnWQbGVSTyX4rsICqZjkb3f6CTSUWpGoGKmlmbb2ZpEuoik7tur9d8Q==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.30.0.tgz",
+            "integrity": "sha512-g78rSRaM6RepFv01QlfiQ9boPX4xMjrD3T4BCk+EnXJGKKxLTIhwYsV40l/+A7rQM2jNF6PE8+JBkdJ8nEtX3w==",
             "license": "MIT",
             "dependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/extension-blockquote": "^3.21.0",
-                "@tiptap/extension-bold": "^3.21.0",
-                "@tiptap/extension-bullet-list": "^3.21.0",
-                "@tiptap/extension-code": "^3.21.0",
-                "@tiptap/extension-code-block": "^3.21.0",
-                "@tiptap/extension-document": "^3.21.0",
-                "@tiptap/extension-dropcursor": "^3.21.0",
-                "@tiptap/extension-gapcursor": "^3.21.0",
-                "@tiptap/extension-hard-break": "^3.21.0",
-                "@tiptap/extension-heading": "^3.21.0",
-                "@tiptap/extension-horizontal-rule": "^3.21.0",
-                "@tiptap/extension-italic": "^3.21.0",
-                "@tiptap/extension-link": "^3.21.0",
-                "@tiptap/extension-list": "^3.21.0",
-                "@tiptap/extension-list-item": "^3.21.0",
-                "@tiptap/extension-list-keymap": "^3.21.0",
-                "@tiptap/extension-ordered-list": "^3.21.0",
-                "@tiptap/extension-paragraph": "^3.21.0",
-                "@tiptap/extension-strike": "^3.21.0",
-                "@tiptap/extension-text": "^3.21.0",
-                "@tiptap/extension-underline": "^3.21.0",
-                "@tiptap/extensions": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/extension-blockquote": "3.30.0",
+                "@tiptap/extension-bold": "3.30.0",
+                "@tiptap/extension-bullet-list": "3.30.0",
+                "@tiptap/extension-code": "3.30.0",
+                "@tiptap/extension-code-block": "3.30.0",
+                "@tiptap/extension-document": "3.30.0",
+                "@tiptap/extension-dropcursor": "3.30.0",
+                "@tiptap/extension-gapcursor": "3.30.0",
+                "@tiptap/extension-hard-break": "3.30.0",
+                "@tiptap/extension-heading": "3.30.0",
+                "@tiptap/extension-horizontal-rule": "3.30.0",
+                "@tiptap/extension-italic": "3.30.0",
+                "@tiptap/extension-link": "3.30.0",
+                "@tiptap/extension-list": "3.30.0",
+                "@tiptap/extension-list-item": "3.30.0",
+                "@tiptap/extension-list-keymap": "3.30.0",
+                "@tiptap/extension-ordered-list": "3.30.0",
+                "@tiptap/extension-paragraph": "3.30.0",
+                "@tiptap/extension-strike": "3.30.0",
+                "@tiptap/extension-text": "3.30.0",
+                "@tiptap/extension-underline": "3.30.0",
+                "@tiptap/extensions": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             },
             "funding": {
                 "type": "github",
@@ -5457,43 +5744,44 @@
             }
         },
         "node_modules/@tiptap/suggestion": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.21.0.tgz",
-            "integrity": "sha512-ShgbaH2hbCRLV+AaVuSx7a/nzPOSdUeW0TNeuxZfWim62MBcx33qtllja1zOoY2tgGXokEihuzFODx83IyvGfQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.30.0.tgz",
+            "integrity": "sha512-ed/SvldxK2GbDgL0QlKjKMARvMHQNSCp/xZXXRVXtJZUTsMq2NPnKQWlyATxxmpIfOTzOOhwPGa1Uz/ED/hIMA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0"
+                "@floating-ui/dom": "^1.0.0",
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/vue-3": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.21.0.tgz",
-            "integrity": "sha512-dfjxBwxg9+GNvsgkCbxLnj/vmG+YZMdcD/qF7bKM710bANWfqzimRUhH5W2KZcxqlYzqpz0u/P0zi7dUMR5IZA==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.30.0.tgz",
+            "integrity": "sha512-Zhqgj0pgOaajDr61l2jP6a7FmddZIk5z8ez+9eezt3zmQl7Ee2SFOY27UvDGkMeAyghvHiV/SPhw7neZWUX7mA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "optionalDependencies": {
-                "@tiptap/extension-bubble-menu": "^3.21.0",
-                "@tiptap/extension-floating-menu": "^3.21.0"
+                "@tiptap/extension-bubble-menu": "^3.30.0",
+                "@tiptap/extension-floating-menu": "^3.30.0"
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/pm": "^3.21.0",
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0",
                 "vue": "^3.0.0"
             }
         },
         "node_modules/@tiptap/y-tiptap": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.2.tgz",
-            "integrity": "sha512-flMn/YW6zTbc6cvDaUPh/NfLRTXDIqgpBUkYzM74KA1snqQwhOMjnRcnpu4hDFrTnPO6QGzr99vRyXEA7M44WA==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.8.tgz",
+            "integrity": "sha512-+kndlSuoUK9sKVRuxbAHXNrbDvyydnG/Y0NFU9XXqaSkI9IRcrjpOf1RGd7NrC9jJXquDqZS96wOQf6eUpP9Dg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -5539,28 +5827,6 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "devOptional": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-            "license": "MIT"
-        },
-        "node_modules/@types/markdown-it": {
-            "version": "14.1.2",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-            "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/linkify-it": "^5",
-                "@types/mdurl": "^2"
-            }
-        },
-        "node_modules/@types/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
             "license": "MIT"
         },
         "node_modules/@types/resolve": {
@@ -6461,14 +6727,14 @@
             "license": "MIT"
         },
         "node_modules/@vueuse/core": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
-            "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
+            "integrity": "sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.21",
-                "@vueuse/metadata": "14.2.1",
-                "@vueuse/shared": "14.2.1"
+                "@vueuse/metadata": "14.4.0",
+                "@vueuse/shared": "14.4.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -6478,13 +6744,13 @@
             }
         },
         "node_modules/@vueuse/integrations": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-14.2.1.tgz",
-            "integrity": "sha512-2LIUpBi/67PoXJGqSDQUF0pgQWpNHh7beiA+KG2AbybcNm+pTGWT6oPGlBgUoDWmYwfeQqM/uzOHqcILpKL7nA==",
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-14.4.0.tgz",
+            "integrity": "sha512-oJz9qTgczvA7L1nXQFRU7h8tQbOCoiceqvMMhT9XYMyOGTqLJ2rEa09PON+nD2t48sZUfeOmg4eaWJXV4sZb/w==",
             "license": "MIT",
             "dependencies": {
-                "@vueuse/core": "14.2.1",
-                "@vueuse/shared": "14.2.1"
+                "@vueuse/core": "14.4.0",
+                "@vueuse/shared": "14.4.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -6544,18 +6810,18 @@
             }
         },
         "node_modules/@vueuse/metadata": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
-            "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.4.0.tgz",
+            "integrity": "sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@vueuse/shared": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
-            "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.4.0.tgz",
+            "integrity": "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -7613,12 +7879,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/crelt": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-            "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-            "license": "MIT"
-        },
         "node_modules/croner": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
@@ -8224,13 +8484,13 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.20.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-            "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.0"
+                "tapable": "^2.3.3"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -8258,9 +8518,9 @@
             }
         },
         "node_modules/errx": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.0.tgz",
-            "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.2.tgz",
+            "integrity": "sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==",
             "license": "MIT"
         },
         "node_modules/es-module-lexer": {
@@ -8329,6 +8589,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -9042,9 +9303,9 @@
             }
         },
         "node_modules/exsolve": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-            "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+            "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
             "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
@@ -9335,13 +9596,13 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.38.0",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-            "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+            "version": "12.43.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+            "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.38.0",
-                "motion-utils": "^12.36.0",
+                "motion-dom": "^12.43.0",
+                "motion-utils": "^12.39.0",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -9394,12 +9655,16 @@
             }
         },
         "node_modules/fuse.js": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
-            "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+            "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/krisk"
             }
         },
         "node_modules/fzf": {
@@ -9633,9 +9898,9 @@
             "license": "MIT"
         },
         "node_modules/hookable": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
-            "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "license": "MIT"
         },
         "node_modules/html-entities": {
@@ -9734,9 +9999,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -9747,6 +10012,16 @@
             "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.2.tgz",
             "integrity": "sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==",
             "license": "MIT"
+        },
+        "node_modules/import-meta-resolve": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/impound": {
             "version": "1.1.5",
@@ -10068,9 +10343,9 @@
             }
         },
         "node_modules/jiti": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -10552,19 +10827,10 @@
                 "url": "https://github.com/sponsors/antonk52"
             }
         },
-        "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^2.0.0"
-            }
-        },
         "node_modules/linkifyjs": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-            "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+            "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
             "license": "MIT"
         },
         "node_modules/listhen": {
@@ -10620,9 +10886,9 @@
             }
         },
         "node_modules/local-pkg": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
-            "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+            "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
             "license": "MIT",
             "dependencies": {
                 "mlly": "^1.7.4",
@@ -10765,39 +11031,10 @@
                 "source-map-js": "^1.2.1"
             }
         },
-        "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
-        "node_modules/markdown-it/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
         "node_modules/marked": {
-            "version": "17.0.5",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
-            "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+            "version": "17.0.6",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+            "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -10811,12 +11048,6 @@
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "license": "CC0-1.0"
-        },
-        "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "license": "MIT"
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -10982,30 +11213,30 @@
             "license": "MIT"
         },
         "node_modules/motion-dom": {
-            "version": "12.38.0",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-            "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+            "version": "12.43.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+            "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
             "license": "MIT",
             "dependencies": {
-                "motion-utils": "^12.36.0"
+                "motion-utils": "^12.39.0"
             }
         },
         "node_modules/motion-utils": {
-            "version": "12.36.0",
-            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-            "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+            "version": "12.39.0",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+            "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
             "license": "MIT"
         },
         "node_modules/motion-v": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.2.0.tgz",
-            "integrity": "sha512-8rrUBt9UMwy45MfLMwHer9J7xBY/rL31S+0U3ZUAouqjH3AOVHvS0NGuXwF4mfWfvb22rfZEv59ZsBc2f1epxQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.3.0.tgz",
+            "integrity": "sha512-J0CCfXtICCni9RjotDUBOs57xNpYI9yyBSohEOxaRHrmjwOtlw291fhRu/mdgEdSasys96R028YDDOAtWBbRaA==",
             "license": "MIT",
             "dependencies": {
-                "framer-motion": "^12.38.0",
+                "framer-motion": "^12.40.0",
                 "hey-listen": "^1.0.8",
-                "motion-dom": "^12.38.0",
-                "motion-utils": "^12.36.0"
+                "motion-dom": "^12.40.0",
+                "motion-utils": "^12.39.0"
             },
             "peerDependencies": {
                 "@vueuse/core": ">=10.0.0",
@@ -11034,9 +11265,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -11833,6 +12064,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/nostics": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
+            "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
+            "license": "MIT"
+        },
         "node_modules/npm-run-path": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -12465,9 +12702,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -12497,9 +12734,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -12516,7 +12753,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -13033,27 +13270,18 @@
             "license": "MIT"
         },
         "node_modules/prosemirror-changeset": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
-            "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+            "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-transform": "^1.0.0"
             }
         },
-        "node_modules/prosemirror-collab": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-            "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "prosemirror-state": "^1.0.0"
-            }
-        },
         "node_modules/prosemirror-commands": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
-            "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+            "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
@@ -13062,9 +13290,9 @@
             }
         },
         "node_modules/prosemirror-dropcursor": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
-            "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+            "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-state": "^1.0.0",
@@ -13116,45 +13344,13 @@
                 "w3c-keyname": "^2.2.0"
             }
         },
-        "node_modules/prosemirror-markdown": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-            "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/markdown-it": "^14.0.0",
-                "markdown-it": "^14.0.0",
-                "prosemirror-model": "^1.25.0"
-            }
-        },
-        "node_modules/prosemirror-menu": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
-            "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
-            "license": "MIT",
-            "dependencies": {
-                "crelt": "^1.0.0",
-                "prosemirror-commands": "^1.0.0",
-                "prosemirror-history": "^1.0.0",
-                "prosemirror-state": "^1.0.0"
-            }
-        },
         "node_modules/prosemirror-model": {
-            "version": "1.25.4",
-            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-            "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+            "version": "1.25.11",
+            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+            "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
             "license": "MIT",
             "dependencies": {
                 "orderedmap": "^2.0.0"
-            }
-        },
-        "node_modules/prosemirror-schema-basic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-            "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-            "license": "MIT",
-            "dependencies": {
-                "prosemirror-model": "^1.25.0"
             }
         },
         "node_modules/prosemirror-schema-list": {
@@ -13192,37 +13388,22 @@
                 "prosemirror-view": "^1.41.4"
             }
         },
-        "node_modules/prosemirror-trailing-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-            "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@remirror/core-constants": "3.0.0",
-                "escape-string-regexp": "^4.0.0"
-            },
-            "peerDependencies": {
-                "prosemirror-model": "^1.22.1",
-                "prosemirror-state": "^1.4.2",
-                "prosemirror-view": "^1.33.8"
-            }
-        },
         "node_modules/prosemirror-transform": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.11.0.tgz",
-            "integrity": "sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+            "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-model": "^1.21.0"
             }
         },
         "node_modules/prosemirror-view": {
-            "version": "1.41.7",
-            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
-            "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
+            "version": "1.42.2",
+            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+            "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
             "license": "MIT",
             "dependencies": {
-                "prosemirror-model": "^1.20.0",
+                "prosemirror-model": "^1.25.8",
                 "prosemirror-state": "^1.0.0",
                 "prosemirror-transform": "^1.1.0"
             }
@@ -13232,15 +13413,6 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "devOptional": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/punycode.js": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -13443,9 +13615,9 @@
             }
         },
         "node_modules/reka-ui": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.9.2.tgz",
-            "integrity": "sha512-/t4e6y1hcG+uDuRfpg6tbMz3uUEvRzNco6NeYTufoJeUghy5Iosxos5YL/p+ieAsid84sdMX9OrgDqpEuCJhBw==",
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.10.1.tgz",
+            "integrity": "sha512-drcOQ4rQtDYAcGCsyQBqQg8QQ+H3B+zDaMJU0h8KPEPMa7g9BHu3zcOi4OB39XJSWizceFoNO0Z9tctSGLOXqg==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.13",
@@ -13456,7 +13628,7 @@
                 "@vueuse/core": "^14.1.0",
                 "@vueuse/shared": "^14.1.0",
                 "aria-hidden": "^1.2.4",
-                "defu": "^6.1.4",
+                "defu": "^6.1.5",
                 "ohash": "^2.0.11"
             },
             "funding": {
@@ -13710,9 +13882,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -14266,9 +14438,9 @@
             }
         },
         "node_modules/tailwind-merge": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-            "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+            "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -14295,15 +14467,15 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-            "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+            "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
             "license": "MIT"
         },
         "node_modules/tapable": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-            "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -14423,9 +14595,9 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -14556,12 +14728,6 @@
             "engines": {
                 "node": ">=14.17"
             }
-        },
-        "node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "license": "MIT"
         },
         "node_modules/ufo": {
             "version": "1.6.4",
@@ -14723,17 +14889,57 @@
             }
         },
         "node_modules/unplugin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-            "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.5",
-                "picomatch": "^4.0.3",
+                "picomatch": "^4.0.4",
                 "webpack-virtual-modules": "^0.6.2"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@farmfe/core": "*",
+                "@rspack/core": "*",
+                "bun-types-no-globals": "*",
+                "esbuild": "*",
+                "rolldown": "*",
+                "rollup": "*",
+                "unloader": "*",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "@farmfe/core": {
+                    "optional": true
+                },
+                "@rspack/core": {
+                    "optional": true
+                },
+                "bun-types-no-globals": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "unloader": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/unplugin-auto-import": {
@@ -14800,19 +15006,19 @@
             }
         },
         "node_modules/unplugin-vue-components": {
-            "version": "31.1.0",
-            "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-31.1.0.tgz",
-            "integrity": "sha512-9EbV5ark21A4BOBt6RJGJXCVD2I1eoxTZL1TAvNgYTokcrFIiuxpufb8owyWn7n+z2x8daz/ltZq6IRRKL3ydQ==",
+            "version": "32.1.0",
+            "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-32.1.0.tgz",
+            "integrity": "sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==",
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^5.0.0",
-                "local-pkg": "^1.1.2",
+                "local-pkg": "^1.2.0",
                 "magic-string": "^0.30.21",
                 "mlly": "^1.8.2",
                 "obug": "^2.1.1",
-                "picomatch": "^4.0.3",
-                "tinyglobby": "^0.2.15",
-                "unplugin": "^2.3.11",
+                "picomatch": "^4.0.4",
+                "tinyglobby": "^0.2.16",
+                "unplugin": "^3.0.0",
                 "unplugin-utils": "^0.3.1"
             },
             "engines": {
@@ -14829,21 +15035,6 @@
                 "@nuxt/kit": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/unplugin-vue-components/node_modules/unplugin": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "acorn": "^8.15.0",
-                "picomatch": "^4.0.3",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": ">=18.12.0"
             }
         },
         "node_modules/unrouting": {
@@ -15222,6 +15413,18 @@
                 "@vue/composition-api": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/verkit": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/verkit/-/verkit-0.3.2.tgz",
+            "integrity": "sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
             }
         },
         "node_modules/vite": {
@@ -15616,9 +15819,9 @@
             }
         },
         "node_modules/vue-component-type-helpers": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.6.tgz",
-            "integrity": "sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==",
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.9.tgz",
+            "integrity": "sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==",
             "license": "MIT"
         },
         "node_modules/vue-devtools-stub": {
@@ -16006,9 +16209,9 @@
             }
         },
         "node_modules/yjs": {
-            "version": "13.6.30",
-            "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
-            "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+            "version": "13.6.32",
+            "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.32.tgz",
+            "integrity": "sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@iconify-json/lucide": "^1.2.98",
         "@iconify-json/simple-icons": "^1.2.74",
-        "@nuxt/ui": "^4.5.1",
+        "@nuxt/ui": "^4.10.0",
         "nuxt": "^4.4.2",
         "openapi-typescript": "^7.13.0",
         "tailwindcss": "^4.2.1",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@iconify-json/lucide": "^1.2.98",
         "@iconify-json/simple-icons": "^1.2.74",
-        "@nuxt/ui": "^4.10.0",
+        "@nuxt/ui": "4.9.0",
         "nuxt": "^4.4.2",
         "openapi-typescript": "^7.13.0",
         "tailwindcss": "^4.2.1",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                  
  New users land on Tranga with no guidance on how to actually get a manga downloading. This adds a short, first-visit-only guided tour using Nuxt UI's `useTour` composable that walks through the real flow — search for a manga, review/set its metadata as the
  source, then match a found download-link — and ends automatically the moment a download actually starts.                                                                                                                                                        
                                                                                                                                                                                                                                                                  
  - Bumps `@nuxt/ui` to `^4.10.0` — `useTour` isn't available in the previously-installed 4.6.0 (it landed at 4.9.0). No breaking changes in that range affect this app.                                                                                          
  - `useAppTour` composable (`app/composables/useAppTour.ts`): a client-only singleton around `useTour` (state must live outside any per-page component, since the app's de-facto layout `TrangaPage` remounts on every navigation), a `localStorage`-backed      
  "seen" flag, and `finishAndPersist()` / `replay()` helpers.                                                                                                                                                                                                     
  - `TourOverlay` component (`app/components/Tour/Overlay.vue`), mounted once in `app.vue` behind `<ClientOnly>`. Starts automatically on first visit and auto-advances as the user actually navigates through the flow (search → `/metadata/:id` → `/manga/:id`) 
  rather than requiring manual "Next" clicks.                                                                                                                                                                                                                     
  - Anchored the steps to real UI elements: the navbar search button, the metadata page's primary action button, and the download-link "Match" button.                                                                                                            
  - The tour finishes the moment a user clicks "Match" (`matched: true`) on a download link — that's the actual download-start trigger in this app; there's no separate "Start Download" button.                                                                  
  - Added a "Replay Tour" button on the Settings page so it isn't a one-shot-forever experience.                                                                                                                                                                  
                                                                                                                                                                                                                                                                  
  ## Test plan                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                  
  - [x] `npm run typecheck` passes                                                                                                                                                                                                                                
  - [x] `npm run lint` passes (no new issues; pre-existing lint debt elsewhere untouched)                                                                                                                                                                         
  - [x] `npm run prettier` applied                                                                                                                                                                                                                                
  - [x] Dev server compiles cleanly with no errors from the new code; `/`, `/settings`, `/metadata/:id`, `/manga/:id` all return 200                                                                                                                              
  - [ ] Manual click-through against a running backend (search → set source → match a link) — not yet done, no browser automation available in the environment this was built in  