### PR TITLE
Set default SERVICES_AUTH_PORT, filling the gap in the 3001/3002/3003…

### DIFF
--- a/Tranga.AppHost/aspire-output/.env
+++ b/Tranga.AppHost/aspire-output/.env
@@ -27,7 +27,7 @@ RABBITMQUSER="tranga"
 SERVICES_AUTH_IMAGE=
 
 # Default container port for services-auth
-SERVICES_AUTH_PORT=
+SERVICES_AUTH_PORT=3005
 
 # Container image name for services-libraries
 SERVICES_LIBRARIES_IMAGE=


### PR DESCRIPTION
services-auth was added without a value for SERVICES_AUTH_PORT in the generated .env, unlike the other four services. aspire publish doesn't backfill values for existing-but-empty keys, so it resolved to an empty string and broke docker compose up ("invalid port range: value is empty"). Same class of gap as SERVICES_TASKS_PORT, fixed the same way in 33896d6f.