### PR TITLE
Fix broken layout on client-side redirect to /setup or /login

### DIFF
--- a/Frontend/app/middleware/auth.global.ts
+++ b/Frontend/app/middleware/auth.global.ts
@@ -18,6 +18,15 @@ export default defineNuxtRouteMiddleware(async (to) => {
     }
 
     if (!status.enabled) return;
-    if (!status.configured) return navigateTo('/setup');
-    if (!getAuthToken()) return navigateTo('/login');
+
+    // On the very first client navigation the server has already rendered `to` (it has no idea a
+    // redirect is coming, since this check is client-only) and Vue hasn't mounted/hydrated yet. A
+    // soft `navigateTo` here would hydrate the setup/login page's markup onto that mismatched
+    // server-rendered DOM, leaving a broken layout until the next refresh. Forcing an external
+    // navigation in that case makes the browser do a real reload so the target route gets its own
+    // clean SSR render instead.
+    const redirect = (path: string) => navigateTo(path, useNuxtApp().isHydrating ? { external: true } : undefined);
+
+    if (!status.configured) return redirect('/setup');
+    if (!getAuthToken()) return redirect('/login');
 });


### PR DESCRIPTION
The auth check is client-only, so on the very first navigation the server renders the originally-requested route with no idea a redirect is coming. If the client middleware then does a soft navigateTo before the app mounts, Vue hydrates the setup/login page onto the mismatched server-rendered DOM, producing a broken layout that only a manual refresh fixes. Force an external (full-reload) navigation in that initial-hydration case so the target route gets its own clean SSR render.