### PR TITLE
Fetch cover/file images through the authenticated client

### DIFF
--- a/Frontend/app/components/DownloadLink/ListCard.vue
+++ b/Frontend/app/components/DownloadLink/ListCard.vue
@@ -2,7 +2,7 @@
     <UBlogPost
         :title="downloadLink.series"
         :description="downloadLink.summary ?? undefined"
-        :image="{ src: `${$apiBaseUrl}/mangas/files/${downloadLink.coverId}`, loading: 'lazy' }"
+        :image="{ src: coverSrc, loading: 'lazy' }"
         external
         class="max-w-90 max-h-120"
         :ui="{
@@ -55,6 +55,8 @@ const props = defineProps<{ downloadLink: ServicesMangaMangaDownloadLink }>();
 const mDl = computed(() => props.downloadLink as ServicesMangaMangaDownloadLink | undefined);
 
 const { downloadExtensions } = await useDownloadExtensions();
+
+const coverSrc = useAuthedImageUrl(() => (props.downloadLink.coverId ? `/mangas/files/${props.downloadLink.coverId}` : undefined));
 
 const updateMatch = async (matched?: boolean, priority?: number) => {
     if (!mDl.value) return;

--- a/Frontend/app/components/Manga/Cover.vue
+++ b/Frontend/app/components/Manga/Cover.vue
@@ -1,17 +1,16 @@
 <template>
-    <img
-        v-if="fileId"
-        :src="`${$apiBaseUrl}/mangas/files/${fileId}`"
-        class="max-h-full w-full aspect-6/9 object-cover object-center"
-        :class="!noBlur && 'blur-md'" />
-    <img
-        v-else-if="mangaId"
-        :src="`${$apiBaseUrl}/mangas/${mangaId}/cover`"
-        class="max-h-full w-full aspect-6/9 object-cover object-center"
-        :class="!noBlur && 'blur-md'" />
+    <img v-if="src" :src="src" class="max-h-full w-full aspect-6/9 object-cover object-center" :class="!noBlur && 'blur-md'" />
     <USkeleton v-else class="aspect-6/9" />
 </template>
 
 <script setup lang="ts">
-defineProps<{ mangaId?: string | null; fileId?: string | null; noBlur?: boolean }>();
+const props = defineProps<{ mangaId?: string | null; fileId?: string | null; noBlur?: boolean }>();
+
+const path = computed(() => {
+    if (props.fileId) return `/mangas/files/${props.fileId}`;
+    if (props.mangaId) return `/mangas/${props.mangaId}/cover`;
+    return undefined;
+});
+
+const src = useAuthedImageUrl(path);
 </script>

--- a/Frontend/app/components/Metadata/ListCard.vue
+++ b/Frontend/app/components/Metadata/ListCard.vue
@@ -2,7 +2,7 @@
     <UBlogPost
         :title="metadata.series"
         :description="metadata.summary ?? undefined"
-        :image="{ src: `${$apiBaseUrl}/mangas/files/${metadata.coverId}`, loading: 'lazy' }"
+        :image="{ src: coverSrc, loading: 'lazy' }"
         :to="mangaId ? `/metadata/${metadata.metadataId}?mangaId=${mangaId}` : `/metadata/${metadata.metadataId}`"
         :target="target"
         external
@@ -51,4 +51,6 @@ const props = defineProps<{
 }>();
 
 const { metadataExtensions } = await useMetadataExtensions();
+
+const coverSrc = useAuthedImageUrl(() => (props.metadata.coverId ? `/mangas/files/${props.metadata.coverId}` : undefined));
 </script>

--- a/Frontend/app/composables/authedImage.ts
+++ b/Frontend/app/composables/authedImage.ts
@@ -1,0 +1,42 @@
+import type { MaybeRefOrGetter } from 'vue';
+
+/**
+ * Fetches an image through the authenticated `$tranga` client (so the Bearer token is sent)
+ * and exposes it as an object URL, since a plain `<img src>` can't carry auth headers itself.
+ */
+export function useAuthedImageUrl(path: MaybeRefOrGetter<string | null | undefined>) {
+    const src = ref<string | undefined>(undefined);
+
+    if (import.meta.client) {
+        const { $tranga } = useNuxtApp();
+        let objectUrl: string | undefined;
+
+        watch(
+            () => toValue(path),
+            async (p) => {
+                if (objectUrl) {
+                    URL.revokeObjectURL(objectUrl);
+                    objectUrl = undefined;
+                }
+                if (!p) {
+                    src.value = undefined;
+                    return;
+                }
+                try {
+                    const blob = await $tranga<Blob>(p, { responseType: 'blob' });
+                    objectUrl = URL.createObjectURL(blob);
+                    src.value = objectUrl;
+                } catch {
+                    src.value = undefined;
+                }
+            },
+            { immediate: true },
+        );
+
+        onScopeDispose(() => {
+            if (objectUrl) URL.revokeObjectURL(objectUrl);
+        });
+    }
+
+    return src;
+}


### PR DESCRIPTION
<img>/UBlogPost image bindings built raw URLs against $apiBaseUrl directly, so no Authorization header was sent and covers/files broke once backend auth was enabled. Route them through the authenticated $tranga client as blobs, bound to object URLs, since plain <img src> requests can't carry custom headers at all.