### PR TITLE
Serve cover/file images at their display size

### DIFF
--- a/Common.Tests/Helpers/ImageHelperTests.cs
+++ b/Common.Tests/Helpers/ImageHelperTests.cs
@@ -58,6 +58,25 @@ public sealed class ImageHelperTests : TrangaTest
         Assert.Equal(originalBytes, image.ToArray());
     }
 
+    [Fact]
+    public async Task AsJpegWithDimensionsResizesToExactTargetSize()
+    {
+        using Image<Rgba32> image = new(40, 20);
+        TrangaImage stream = new();
+        image.SaveAsPng(stream);
+        stream.Position = 0;
+
+        MemoryStream result = await stream.AsJpeg(10, 10, ct);
+
+        IImageFormat format = await Image.DetectFormatAsync(result, ct);
+        Assert.Equal("JPEG", format.Name);
+
+        result.Position = 0;
+        ImageInfo info = await Image.IdentifyAsync(result, ct);
+        Assert.Equal(10, info.Width);
+        Assert.Equal(10, info.Height);
+    }
+
     [Theory]
     [InlineData("png")]
     [InlineData("bmp")]

--- a/Common/Helpers/ImageHelper.cs
+++ b/Common/Helpers/ImageHelper.cs
@@ -1,4 +1,5 @@
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
 
 namespace Common.Helpers;
 
@@ -38,6 +39,34 @@ public static class ImageHelper
         memoryStream.Position = 0;
         using Image image = await Image.LoadAsync(memoryStream, ct);
         memoryStream.Position = 0;
+        MemoryStream ret = new();
+        await image.SaveAsJpegAsync(ret, ct);
+        ret.Position = 0;
+        return ret;
+    }
+
+    /// <summary>
+    /// Resizes the image to exactly <paramref name="width"/> x <paramref name="height"/>, cropping any overflow
+    /// (equivalent to CSS <c>object-fit: cover</c>), and returns it as a new JPEG-encoded stream.
+    /// </summary>
+    /// <param name="memoryStream"></param>
+    /// <param name="width">Target width in pixels</param>
+    /// <param name="height">Target height in pixels</param>
+    /// <param name="ct"></param>
+    /// <exception cref="ArgumentNullException">The stream is null</exception>
+    /// <exception cref="NotSupportedException">The stream is not readable or the image format is not supported.</exception>
+    /// <exception cref="InvalidImageContentException">The encoded image contains invalid content.</exception>
+    /// <exception cref="UnknownImageFormatException">The encoded image format is unknown.</exception>
+    public static async Task<MemoryStream> AsJpeg(this TrangaImage memoryStream, int width, int height, CancellationToken ct)
+    {
+        memoryStream.Position = 0;
+        using Image image = await Image.LoadAsync(memoryStream, ct);
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Crop,
+            Size = new Size(width, height),
+            Position = AnchorPositionMode.Center
+        }));
         MemoryStream ret = new();
         await image.SaveAsJpegAsync(ret, ct);
         ret.Position = 0;

--- a/Frontend/app/api/tranga/types.gen.ts
+++ b/Frontend/app/api/tranga/types.gen.ts
@@ -290,7 +290,12 @@ export type GetMangasByMangaIdResponses = {
 
 export type GetMangasByMangaIdResponse = GetMangasByMangaIdResponses[keyof GetMangasByMangaIdResponses];
 
-export type GetMangasByMangaIdCoverData = { body?: never; path: { mangaId: string }; query?: never; url: '/mangas/{mangaId}/cover' };
+export type GetMangasByMangaIdCoverData = {
+    body?: never;
+    path: { mangaId: string };
+    query?: { width?: number | string; height?: number | string };
+    url: '/mangas/{mangaId}/cover';
+};
 
 export type GetMangasByMangaIdCoverErrors = {
     /**
@@ -758,7 +763,12 @@ export type GetMangasDownloadLinksByDownloadIdResponses = {
 export type GetMangasDownloadLinksByDownloadIdResponse =
     GetMangasDownloadLinksByDownloadIdResponses[keyof GetMangasDownloadLinksByDownloadIdResponses];
 
-export type GetMangasFilesByFileIdData = { body?: never; path: { fileId: string }; query?: never; url: '/mangas/files/{fileId}' };
+export type GetMangasFilesByFileIdData = {
+    body?: never;
+    path: { fileId: string };
+    query?: { width?: number | string; height?: number | string };
+    url: '/mangas/files/{fileId}';
+};
 
 export type GetMangasFilesByFileIdErrors = {
     /**

--- a/Frontend/app/components/DownloadLink/ListCard.vue
+++ b/Frontend/app/components/DownloadLink/ListCard.vue
@@ -56,7 +56,9 @@ const mDl = computed(() => props.downloadLink as ServicesMangaMangaDownloadLink 
 
 const { downloadExtensions } = await useDownloadExtensions();
 
-const coverSrc = useAuthedImageUrl(() => (props.downloadLink.coverId ? `/mangas/files/${props.downloadLink.coverId}` : undefined));
+const coverSrc = useAuthedImageUrl(() =>
+    props.downloadLink.coverId ? withCoverSize(`/mangas/files/${props.downloadLink.coverId}`, COVER_SIZES.blogCard) : undefined,
+);
 
 const updateMatch = async (matched?: boolean, priority?: number) => {
     if (!mDl.value) return;

--- a/Frontend/app/components/Manga/Cover.vue
+++ b/Frontend/app/components/Manga/Cover.vue
@@ -4,12 +4,13 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ mangaId?: string | null; fileId?: string | null; noBlur?: boolean }>();
+const props = defineProps<{ mangaId?: string | null; fileId?: string | null; noBlur?: boolean; size: CoverSize }>();
 
 const path = computed(() => {
-    if (props.fileId) return `/mangas/files/${props.fileId}`;
-    if (props.mangaId) return `/mangas/${props.mangaId}/cover`;
-    return undefined;
+    let base: string | undefined;
+    if (props.fileId) base = `/mangas/files/${props.fileId}`;
+    else if (props.mangaId) base = `/mangas/${props.mangaId}/cover`;
+    return base ? withCoverSize(base, props.size) : undefined;
 });
 
 const src = useAuthedImageUrl(path);

--- a/Frontend/app/components/Manga/List.vue
+++ b/Frontend/app/components/Manga/List.vue
@@ -15,6 +15,7 @@
             <MangaCover
                 :file-id="manga.metadataEntry?.coverId"
                 :manga-id="manga.mangaId"
+                :size="COVER_SIZES.card"
                 no-blur
                 class="z-0"
                 :class="manga.metadataEntry?.nsfw ? 'blur-md' : 'blur-xs'" />

--- a/Frontend/app/components/Manga/MergeConfirm.vue
+++ b/Frontend/app/components/Manga/MergeConfirm.vue
@@ -21,7 +21,7 @@
 
                     <div class="flex gap-3 rounded-md border border-default p-3 mt-1">
                         <div class="flex-1 min-w-0">
-                            <MangaCover :file-id="previewMetadata?.coverId" no-blur class="rounded" />
+                            <MangaCover :file-id="previewMetadata?.coverId" :size="COVER_SIZES.card" no-blur class="rounded" />
                         </div>
                         <div class="flex-1 min-w-0 flex flex-col gap-1">
                             <p class="text-xs text-dimmed uppercase tracking-wide">Preview</p>

--- a/Frontend/app/components/Manga/Page.vue
+++ b/Frontend/app/components/Manga/Page.vue
@@ -9,6 +9,7 @@
                     :file-id="manga?.metadataEntry?.coverId"
                     :manga-id="manga?.mangaId"
                     :no-blur="!manga?.metadataEntry?.nsfw"
+                    :size="COVER_SIZES.hero"
                     class="aspect-6/9 w-full max-w-2xs mx-auto md:mx-0" />
 
                 <div class="flex flex-col gap-2">

--- a/Frontend/app/components/Manga/Search.vue
+++ b/Frontend/app/components/Manga/Search.vue
@@ -20,6 +20,7 @@
                     :file-id="item?.fileId"
                     :manga-id="item?.mangaId"
                     :no-blur="!item?.metadataEntry?.nsfw"
+                    :size="COVER_SIZES.tiny"
                     class="aspect-6/9 max-h-6 max-w-9" />
             </template>
             <template #footer>

--- a/Frontend/app/components/Metadata/ListCard.vue
+++ b/Frontend/app/components/Metadata/ListCard.vue
@@ -52,5 +52,7 @@ const props = defineProps<{
 
 const { metadataExtensions } = await useMetadataExtensions();
 
-const coverSrc = useAuthedImageUrl(() => (props.metadata.coverId ? `/mangas/files/${props.metadata.coverId}` : undefined));
+const coverSrc = useAuthedImageUrl(() =>
+    props.metadata.coverId ? withCoverSize(`/mangas/files/${props.metadata.coverId}`, COVER_SIZES.blogCard) : undefined,
+);
 </script>

--- a/Frontend/app/components/Metadata/Page.vue
+++ b/Frontend/app/components/Metadata/Page.vue
@@ -46,9 +46,18 @@
             <!-- Passes through the slots -->
             <template v-for="(_, slotName) in $slots" #[slotName]="slotProps" :key="slotName">
                 <slot v-if="slotName !== 'default'" :name="slotName as unknown" v-bind="slotProps" />
-                <MangaCover v-else :file-id="metadata?.coverId" :no-blur="!metadata?.nsfw" class="aspect-6/9 max-h-sm max-w-sm" />
+                <MangaCover
+                    v-else
+                    :file-id="metadata?.coverId"
+                    :no-blur="!metadata?.nsfw"
+                    :size="COVER_SIZES.hero"
+                    class="aspect-6/9 max-h-sm max-w-sm" />
             </template>
-            <MangaCover :file-id="metadata?.coverId" :no-blur="!metadata?.nsfw" class="aspect-6/9 max-h-sm max-w-sm" />
+            <MangaCover
+                :file-id="metadata?.coverId"
+                :no-blur="!metadata?.nsfw"
+                :size="COVER_SIZES.hero"
+                class="aspect-6/9 max-h-sm max-w-sm" />
         </UPageCTA>
 
         <UPageSection :ui="{ container: 'sm:py-8 lg:py-8' }">

--- a/Frontend/app/utils/coverSizes.ts
+++ b/Frontend/app/utils/coverSizes.ts
@@ -1,0 +1,16 @@
+export interface CoverSize {
+    width: number;
+    height: number;
+}
+
+export const COVER_SIZES = {
+    tiny: { width: 24, height: 36 }, // Manga/Search.vue command-palette icon
+    card: { width: 240, height: 360 }, // Manga/List.vue grid card, Manga/MergeConfirm.vue preview
+    hero: { width: 256, height: 384 }, // Manga/Page.vue and Metadata/Page.vue hero
+    blogCard: { width: 360, height: 249 }, // Metadata/ListCard.vue, DownloadLink/ListCard.vue (13:9 UBlogPost header)
+} as const satisfies Record<string, CoverSize>;
+
+export function withCoverSize(path: string, size: CoverSize): string {
+    const separator = path.includes('?') ? '&' : '?';
+    return `${path}${separator}width=${size.width}&height=${size.height}`;
+}

--- a/Services.Manga.Tests/Features/File/GetFileEndpointTests.cs
+++ b/Services.Manga.Tests/Features/File/GetFileEndpointTests.cs
@@ -4,6 +4,8 @@ using Services.Manga.Database;
 using Services.Manga.Database.Helpers;
 using Services.Manga.Features.File;
 using Services.Manga.Tests.Helpers;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Services.Manga.Tests.Features.File;
 
@@ -28,6 +30,53 @@ public class GetFileEndpointTests : TrangaTest, IDisposable
         await context.SaveChangesAsync(ct);
 
         Results<FileStreamHttpResult, NotFound, InternalServerError> result = await GetFileEndpoint.Handle(context, file.FileId, ct);
+
+        FileStreamHttpResult fileResult = Assert.IsType<FileStreamHttpResult>(result.Result);
+        Assert.Equal("application/octet-stream", fileResult.ContentType);
+        using MemoryStream buffer = new();
+        await fileResult.FileStream.CopyToAsync(buffer, ct);
+        Assert.Equal(content, buffer.ToArray());
+    }
+
+    [Fact]
+    public async Task GetFile_ResizesImageWhenDimensionsGiven()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+        using Image<Rgba32> source = new(40, 20);
+        MemoryStream sourceStream = new();
+        source.SaveAsJpeg(sourceStream);
+        DbFile file = new() { FileId = Guid.NewGuid(), Path = _directory, Name = "cover.jpg", MimeType = "image/jpeg" };
+        await file.SaveFile(sourceStream, ct);
+        await context.AddAsync(file, ct);
+        await context.SaveChangesAsync(ct);
+
+        Results<FileStreamHttpResult, NotFound, InternalServerError> result =
+            await GetFileEndpoint.Handle(context, file.FileId, ct, width: 10, height: 10);
+
+        FileStreamHttpResult fileResult = Assert.IsType<FileStreamHttpResult>(result.Result);
+        Assert.Equal("image/jpeg", fileResult.ContentType);
+        using MemoryStream buffer = new();
+        await fileResult.FileStream.CopyToAsync(buffer, ct);
+        buffer.Position = 0;
+        ImageInfo info = await Image.IdentifyAsync(buffer, ct);
+        Assert.Equal(10, info.Width);
+        Assert.Equal(10, info.Height);
+
+        Assert.True(System.IO.File.Exists(Path.Combine(_directory, "cache", "cover_10x10.jpg")));
+    }
+
+    [Fact]
+    public async Task GetFile_IgnoresDimensionsForNonImageFiles()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+        byte[] content = "file-bytes"u8.ToArray();
+        DbFile file = new() { FileId = Guid.NewGuid(), Path = _directory, Name = "file.bin", MimeType = "application/octet-stream" };
+        await file.SaveFile(new MemoryStream(content), ct);
+        await context.AddAsync(file, ct);
+        await context.SaveChangesAsync(ct);
+
+        Results<FileStreamHttpResult, NotFound, InternalServerError> result =
+            await GetFileEndpoint.Handle(context, file.FileId, ct, width: 10, height: 10);
 
         FileStreamHttpResult fileResult = Assert.IsType<FileStreamHttpResult>(result.Result);
         Assert.Equal("application/octet-stream", fileResult.ContentType);

--- a/Services.Manga.Tests/Features/Manga/GetMangaCoverEndpointTests.cs
+++ b/Services.Manga.Tests/Features/Manga/GetMangaCoverEndpointTests.cs
@@ -5,6 +5,8 @@ using Services.Manga.Database;
 using Services.Manga.Database.Helpers;
 using Services.Manga.Features.Manga;
 using Services.Manga.Tests.Helpers;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Services.Manga.Tests.Features.Manga;
 
@@ -38,6 +40,43 @@ public class GetMangaCoverEndpointTests : TrangaTest, IDisposable
         using MemoryStream buffer = new();
         await fileResult.FileStream.CopyToAsync(buffer, ct);
         Assert.Equal(content, buffer.ToArray());
+    }
+
+    [Fact]
+    public async Task GetMangaCover_ResizesAndCachesWhenDimensionsGiven()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+        using Image<Rgba32> source = new(40, 20);
+        MemoryStream sourceStream = new();
+        source.SaveAsJpeg(sourceStream);
+        DbFile file = new() { FileId = Guid.NewGuid(), Path = _coverDirectory, Name = "cover.jpg", MimeType = "image/jpeg" };
+        await file.SaveFile(sourceStream, ct);
+        await context.AddAsync(file, ct);
+        await context.SaveChangesAsync(ct);
+
+        (DbManga manga, _, _) = await TestDataBuilder.SeedMangaWithChosenMetadata(context, coverId: file.FileId, ct: ct);
+
+        Results<FileStreamHttpResult, NoContent, NotFound, InternalServerError> result =
+            await GetMangaCoverEndpoint.Handle(context, manga.MangaId, ct, width: 10, height: 10);
+
+        FileStreamHttpResult fileResult = Assert.IsType<FileStreamHttpResult>(result.Result);
+        Assert.Equal("image/jpeg", fileResult.ContentType);
+        using MemoryStream buffer = new();
+        await fileResult.FileStream.CopyToAsync(buffer, ct);
+        buffer.Position = 0;
+        ImageInfo info = await Image.IdentifyAsync(buffer, ct);
+        Assert.Equal(10, info.Width);
+        Assert.Equal(10, info.Height);
+
+        string cachePath = Path.Combine(_coverDirectory, "cache", "cover_10x10.jpg");
+        Assert.True(System.IO.File.Exists(cachePath));
+
+        Results<FileStreamHttpResult, NoContent, NotFound, InternalServerError> cachedResult =
+            await GetMangaCoverEndpoint.Handle(context, manga.MangaId, ct, width: 10, height: 10);
+        FileStreamHttpResult cachedFileResult = Assert.IsType<FileStreamHttpResult>(cachedResult.Result);
+        using MemoryStream cachedBuffer = new();
+        await cachedFileResult.FileStream.CopyToAsync(cachedBuffer, ct);
+        Assert.Equal(buffer.ToArray(), cachedBuffer.ToArray());
     }
 
     [Fact]

--- a/Services.Manga/Database/Helpers/DbFileHelper.cs
+++ b/Services.Manga/Database/Helpers/DbFileHelper.cs
@@ -1,3 +1,5 @@
+using Common.Helpers;
+
 namespace Services.Manga.Database.Helpers;
 
 /// <summary>
@@ -44,5 +46,54 @@ public static class DbFileHelper
         {
             throw new FileLoadException();
         }
+    }
+
+    private const int MaxResizeDimension = 2048;
+
+    /// <summary>
+    /// Reads the on-disk contents referenced by <paramref name="file"/> into memory, resizing to
+    /// <paramref name="width"/> x <paramref name="height"/> (cropping to fill, like CSS <c>object-fit: cover</c>)
+    /// when both are given and <paramref name="file"/> is an image. Resized variants are cached on disk next to
+    /// the original, so repeated requests for the same dimensions are served without re-encoding.
+    /// </summary>
+    /// <param name="file">The file entity describing what to load.</param>
+    /// <param name="width">Target width in pixels, or null/non-positive to skip resizing.</param>
+    /// <param name="height">Target height in pixels, or null/non-positive to skip resizing.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The (possibly resized) file contents, and the MIME type of the returned contents.</returns>
+    /// <exception cref="FileLoadException">File could not be loaded</exception>
+    public static async Task<(MemoryStream Stream, string MimeType)> LoadFile(this DbFile file, int? width, int? height, CancellationToken ct)
+    {
+        if (width is not > 0 || height is not > 0 || !file.MimeType.StartsWith("image/", StringComparison.Ordinal))
+            return (await file.LoadFile(ct), file.MimeType);
+
+        int targetWidth = Math.Min(width.Value, MaxResizeDimension);
+        int targetHeight = Math.Min(height.Value, MaxResizeDimension);
+
+        string cacheDirectory = Path.Join(file.Path, "cache");
+        string cacheName = $"{Path.GetFileNameWithoutExtension(file.Name)}_{targetWidth}x{targetHeight}.jpg";
+        string cachePath = Path.Join(cacheDirectory, cacheName);
+
+        if (File.Exists(cachePath))
+        {
+            await using FileStream cachedFs = new(cachePath, FileMode.Open, FileAccess.Read);
+            MemoryStream cached = new();
+            await cachedFs.CopyToAsync(cached, ct);
+            cached.Position = 0;
+            return (cached, "image/jpeg");
+        }
+
+        MemoryStream original = await file.LoadFile(ct);
+        TrangaImage resizable = new();
+        await original.CopyToAsync(resizable, ct);
+        MemoryStream resized = await resizable.AsJpeg(targetWidth, targetHeight, ct);
+
+        Directory.CreateDirectory(cacheDirectory);
+        resized.Position = 0;
+        await using (FileStream cacheFs = new(cachePath, FileMode.Create, FileAccess.Write))
+            await resized.CopyToAsync(cacheFs, ct);
+        resized.Position = 0;
+
+        return (resized, "image/jpeg");
     }
 }

--- a/Services.Manga/Features/File/GetFileEndpoint.cs
+++ b/Services.Manga/Features/File/GetFileEndpoint.cs
@@ -17,18 +17,20 @@ internal abstract class GetFileEndpoint
     /// <param name="mangaContext"></param>
     /// <param name="fileId">ID of File</param>
     /// <param name="ct"></param>
+    /// <param name="width">Target width in pixels; resizes (cropping to fill) when given together with <paramref name="height"/> and the file is an image</param>
+    /// <param name="height">Target height in pixels; resizes (cropping to fill) when given together with <paramref name="width"/> and the file is an image</param>
     /// <returns>File</returns>
     /// <response code="200">File</response>
     /// <response code="404">File with ID does not exist</response>
-    public static async Task<Results<FileStreamHttpResult, NotFound, InternalServerError>> Handle(MangaContext mangaContext, [FromRoute] Guid fileId, CancellationToken ct)
+    public static async Task<Results<FileStreamHttpResult, NotFound, InternalServerError>> Handle(MangaContext mangaContext, [FromRoute] Guid fileId, CancellationToken ct, [FromQuery] int? width = null, [FromQuery] int? height = null)
     {
         if (await mangaContext.Files.FirstOrDefaultAsync(f => f.FileId == fileId, ct) is not { } file)
             return TypedResults.NotFound();
 
         try
         {
-            MemoryStream memoryStream = await file.LoadFile(ct);
-            return TypedResults.File(memoryStream, file.MimeType, file.Name);
+            (MemoryStream memoryStream, string mimeType) = await file.LoadFile(width, height, ct);
+            return TypedResults.File(memoryStream, mimeType, file.Name);
         }
         catch (FileLoadException)
         {

--- a/Services.Manga/Features/Manga/GetMangaCoverEndpoint.cs
+++ b/Services.Manga/Features/Manga/GetMangaCoverEndpoint.cs
@@ -17,11 +17,13 @@ internal abstract class GetMangaCoverEndpoint
     /// <param name="mangaContext"></param>
     /// <param name="mangaId">ID of Manga</param>
     /// <param name="ct"></param>
+    /// <param name="width">Target width in pixels; resizes (cropping to fill) when given together with <paramref name="height"/></param>
+    /// <param name="height">Target height in pixels; resizes (cropping to fill) when given together with <paramref name="width"/></param>
     /// <returns>Cover-File</returns>
     /// <response code="200">Cover-File</response>
     /// <response code="204">Cover does not exist</response>
     /// <response code="404">Manga with requested ID does not exist</response>
-    public static async Task<Results<FileStreamHttpResult, NoContent, NotFound, InternalServerError>> Handle(MangaContext mangaContext, [FromRoute] Guid mangaId, CancellationToken ct)
+    public static async Task<Results<FileStreamHttpResult, NoContent, NotFound, InternalServerError>> Handle(MangaContext mangaContext, [FromRoute] Guid mangaId, CancellationToken ct, [FromQuery] int? width = null, [FromQuery] int? height = null)
     {
         if (await mangaContext.GetManga(mangaId, ct) is not { } source)
             return TypedResults.NotFound();
@@ -32,7 +34,7 @@ internal abstract class GetMangaCoverEndpoint
         if (await mangaContext.Files.FirstOrDefaultAsync(f => f.FileId == source.Metadata.CoverId, cancellationToken: ct) is not { } file)
             return TypedResults.InternalServerError();
 
-        MemoryStream fileStream = await file.LoadFile(ct);
-        return TypedResults.Stream(fileStream, file.MimeType, file.Name);
+        (MemoryStream fileStream, string mimeType) = await file.LoadFile(width, height, ct);
+        return TypedResults.Stream(fileStream, mimeType, file.Name);
     }
 }

--- a/Services.Manga/openapi/Services.Manga.json
+++ b/Services.Manga/openapi/Services.Manga.json
@@ -80,6 +80,30 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "width",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "height",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
           }
         ],
         "responses": {
@@ -893,6 +917,30 @@
             "schema": {
               "type": "string",
               "format": "uuid"
+            }
+          },
+          {
+            "name": "width",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "height",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
             }
           }
         ],


### PR DESCRIPTION
Covers were always sent at full resolution regardless of where they render. GetMangaCoverEndpoint and GetFileEndpoint now accept optional width/height query params and resize with ImageSharp in cover-crop mode; resized variants are cached on disk next to the original so repeat requests for the same size skip re-encoding. The frontend requests each cover at the exact pixel box it's displayed in via a shared set of size constants (tiny/card/hero/blogCard) measured from every current usage.