### PR TITLE
Contain manga card title stacking so it stops overlaying the search m…

### DIFF
--- a/Frontend/app/components/Manga/List.vue
+++ b/Frontend/app/components/Manga/List.vue
@@ -4,7 +4,7 @@
             v-for="manga in mangas"
             :key="manga.mangaId"
             v-bind="selectMode ? {} : { to: `/manga/${manga.mangaId}` }"
-            class="relative overflow-clip h-90 w-60 aspect-6/9"
+            class="relative isolate overflow-clip h-90 w-60 aspect-6/9"
             :class="selectMode && 'cursor-pointer'"
             :ui="{ container: 'p-0 sm:p-0' }"
             @click="selectMode ? $emit('select', manga) : useOverlay().closeAll()">


### PR DESCRIPTION
…odal

The card only had position:relative on its title's ancestor, which never establishes its own stacking context, so the title's z-1 escaped up to the page root and painted over global overlays like the search dialog (whose Modal theme sets no explicit z-index). Adding isolate contains it to the card.