### PR TITLE
Set Manga.Monitored when a download link is matched

### DIFF
--- a/Services.Manga.Tests/Features/Manga/PatchMangaDownloadLinkEndpointTests.cs
+++ b/Services.Manga.Tests/Features/Manga/PatchMangaDownloadLinkEndpointTests.cs
@@ -71,6 +71,22 @@ public class PatchMangaDownloadLinkEndpointTests : TrangaTest
     }
 
     [Fact]
+    public async Task PatchMangaDownloadLink_SetsMangaMonitoredWhenMatched()
+    {
+        await using MangaContext context = MangaContextFactory.Create();
+        (DbManga manga, _, _) = await TestDataBuilder.SeedMangaWithChosenMetadata(context, monitored: false, ct: ct);
+        DbMangaDownloadLinks link = await TestDataBuilder.SeedMangaDownloadLink(context, manga, matched: false, priority: 0, ct: ct);
+        Assert.False(manga.Monitored);
+
+        Results<Ok, NotFound> result = await PatchMangaDownloadLinkEndpoint.Handle(
+            context, CreateEventPublisher(channelOpen: true), manga.MangaId, link.DownloadLinkId,
+            new PatchMangaDownloadLinkEndpoint.PatchMangaDownloadLinkRequest(Matched: true, Priority: 0), ct);
+
+        Assert.IsType<Ok>(result.Result);
+        Assert.True((await context.Mangas.SingleAsync(m => m.MangaId == manga.MangaId, ct)).Monitored);
+    }
+
+    [Fact]
     public async Task PatchMangaDownloadLink_Returns404ForUnknownLink()
     {
         await using MangaContext context = MangaContextFactory.Create();

--- a/Services.Manga/Features/Manga/PatchMangaDownloadLinkEndpoint.cs
+++ b/Services.Manga/Features/Manga/PatchMangaDownloadLinkEndpoint.cs
@@ -39,7 +39,11 @@ internal abstract class PatchMangaDownloadLinkEndpoint
 
         entry.Priority = req.Priority;
         entry.Matched = req.Matched;
-        
+
+        // Start monitoring the Manga for new chapters once we have a matched source
+        if (entry.Matched)
+            entry.Manga.Monitored = true;
+
         await mangaContext.SaveChangesAsync(ct);
 
         // Fetch chapters if we started matching

--- a/Services.Tasks.Tests/Tasks/PeriodicMangaChapterFetcherTaskTests.cs
+++ b/Services.Tasks.Tests/Tasks/PeriodicMangaChapterFetcherTaskTests.cs
@@ -1,0 +1,72 @@
+using Common.Tests;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Services.Manga.Database;
+using Services.Tasks.Tasks;
+using Services.Tasks.Tests.Helpers;
+using Services.Tasks.WorkerLogic;
+
+namespace Services.Tasks.Tests.Tasks;
+
+public class PeriodicMangaChapterFetcherTaskTests : TrangaTest
+{
+    [Fact]
+    public async Task RunAsync_QueuesGetMangaChaptersTask_OnlyForMonitoredMangas()
+    {
+        IServiceProvider services = BuildServices();
+        Guid monitoredMangaId = Guid.CreateVersion7();
+        Guid unmonitoredMangaId = Guid.CreateVersion7();
+
+        using (IServiceScope seedScope = services.CreateScope())
+        {
+            MangaContext seedCtx = seedScope.ServiceProvider.GetRequiredService<MangaContext>();
+            await seedCtx.Mangas.AddRangeAsync(
+            [
+                new DbManga { MangaId = monitoredMangaId, Monitored = true },
+                new DbManga { MangaId = unmonitoredMangaId, Monitored = false }
+            ], ct);
+            await seedCtx.SaveChangesAsync(ct);
+        }
+
+        PeriodicMangaChapterFetcherTask task = new();
+        try
+        {
+            using IServiceScope scope = services.CreateScope();
+            await task.ExecuteAsync(scope, NoOpLogger.Instance, ct);
+
+            GetMangaChaptersTask[] created = TasksCollection.RunOnceTasks.Values
+                .OfType<GetMangaChaptersTask>()
+                .Where(t => t.MangaId == monitoredMangaId || t.MangaId == unmonitoredMangaId)
+                .ToArray();
+
+            GetMangaChaptersTask queuedTask = Assert.Single(created);
+            Assert.Equal(monitoredMangaId, queuedTask.MangaId);
+        }
+        finally
+        {
+            foreach (Guid taskId in TasksCollection.RunOnceTasks.Values
+                         .OfType<GetMangaChaptersTask>()
+                         .Where(t => t.MangaId == monitoredMangaId || t.MangaId == unmonitoredMangaId)
+                         .Select(t => t.TaskId)
+                         .ToArray())
+            {
+                TasksCollection.RunOnceTasks.TryRemove(taskId, out _);
+            }
+        }
+    }
+
+    private static IServiceProvider BuildServices()
+    {
+        string dbPath = Path.Combine(Path.GetTempPath(), "TrangaTests", "Services.Tasks.Tests.MangaContext", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+        ServiceCollection services = new();
+        services.AddDbContext<MangaContext>(options => options.UseSqlite($"Data Source={dbPath}"));
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        using IServiceScope scope = provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<MangaContext>().Database.EnsureCreated();
+
+        return provider;
+    }
+}


### PR DESCRIPTION
PeriodicMangaChapterFetcherTask queries DbManga.Monitored to find mangas to re-check for new chapters, but nothing in the normal add-manga flow ever set that flag - it always reported "Got 0 Mangas". Matching a download source (the "Match" button, PatchMangaDownloadLinkEndpoint) is the actual moment a manga starts being watched, so flip Monitored there too, alongside the existing DownloadLinkModifiedEvent publish.