### PR TITLE
Add login lockout and a reset-password CLI for Services.Auth

### DIFF
--- a/Common.Database/Auth/DbCredential.cs
+++ b/Common.Database/Auth/DbCredential.cs
@@ -14,6 +14,12 @@ public sealed record DbCredential
     /// <summary>PBKDF2 hash of the password, formatted as <c>"{iterations}.{saltBase64}.{hashBase64}"</c>.</summary>
     public string PasswordHash { get; init; } = string.Empty;
 
+    /// <summary>Consecutive failed login attempts since the last successful login. Drives <see cref="Common.Services.Authentication.LoginLockoutPolicy"/>.</summary>
+    public int FailedLoginAttempts { get; init; } = 0;
+
+    /// <summary>Set once <see cref="FailedLoginAttempts"/> crosses <see cref="Common.Services.Authentication.LoginLockoutPolicy.Threshold"/>; login is rejected without checking the password until this passes.</summary>
+    public DateTimeOffset? LockedUntil { get; init; }
+
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
 
     public DateTimeOffset UpdatedAt { get; init; } = DateTimeOffset.UtcNow;

--- a/Common.Database/Auth/Migrations/20260813205432_AddLoginLockoutToCredential.Designer.cs
+++ b/Common.Database/Auth/Migrations/20260813205432_AddLoginLockoutToCredential.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Common.Database.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Common.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthContext))]
-    partial class AuthContextModelSnapshot : ModelSnapshot
+    [Migration("20260813205432_AddLoginLockoutToCredential")]
+    partial class AddLoginLockoutToCredential
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Common.Database/Auth/Migrations/20260813205432_AddLoginLockoutToCredential.cs
+++ b/Common.Database/Auth/Migrations/20260813205432_AddLoginLockoutToCredential.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Common.Database.Auth.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLoginLockoutToCredential : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FailedLoginAttempts",
+                table: "Credentials",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LockedUntil",
+                table: "Credentials",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FailedLoginAttempts",
+                table: "Credentials");
+
+            migrationBuilder.DropColumn(
+                name: "LockedUntil",
+                table: "Credentials");
+        }
+    }
+}

--- a/Common.Services.Tests/Authentication/LoginLockoutPolicyTests.cs
+++ b/Common.Services.Tests/Authentication/LoginLockoutPolicyTests.cs
@@ -1,0 +1,59 @@
+using Common.Services.Authentication;
+using Common.Tests;
+
+namespace Common.Services.Tests.Authentication;
+
+public class LoginLockoutPolicyTests : TrangaTest
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void ComputeLockout_BelowThreshold_ReturnsNull(int failedAttempts)
+    {
+        Assert.Null(LoginLockoutPolicy.ComputeLockout(failedAttempts));
+    }
+
+    [Theory]
+    [InlineData(3, 10)]
+    [InlineData(4, 15)]
+    [InlineData(5, 22.5)]
+    public void ComputeLockout_AtOrAboveThreshold_GrowsByFactorOfOnePointFive(int failedAttempts, double expectedSeconds)
+    {
+        TimeSpan? lockout = LoginLockoutPolicy.ComputeLockout(failedAttempts);
+
+        Assert.NotNull(lockout);
+        Assert.Equal(expectedSeconds, lockout.Value.TotalSeconds, precision: 3);
+    }
+
+    [Fact]
+    public void ComputeLockout_IsCappedAtOneDay()
+    {
+        TimeSpan? lockout = LoginLockoutPolicy.ComputeLockout(failedAttempts: 30);
+
+        Assert.Equal(TimeSpan.FromDays(1), lockout);
+    }
+
+    [Fact]
+    public void ComputeLockout_NeverExceedsOneDay_EvenForVeryLargeAttemptCounts()
+    {
+        TimeSpan? lockout = LoginLockoutPolicy.ComputeLockout(failedAttempts: 1000);
+
+        Assert.Equal(TimeSpan.FromDays(1), lockout);
+    }
+
+    [Theory]
+    [InlineData(1, "1s")]
+    [InlineData(10, "10s")]
+    [InlineData(59, "59s")]
+    [InlineData(60, "1m 0s")]
+    [InlineData(80, "1m 20s")]
+    [InlineData(3600, "1h 0m")]
+    [InlineData(11040, "3h 4m")]
+    [InlineData(86400, "1 day")]
+    [InlineData(200000, "1 day")]
+    public void Format_ProducesHumanReadableDuration(int seconds, string expected)
+    {
+        Assert.Equal(expected, LoginLockoutPolicy.Format(TimeSpan.FromSeconds(seconds)));
+    }
+}

--- a/Common.Services/Authentication/LoginLockoutPolicy.cs
+++ b/Common.Services/Authentication/LoginLockoutPolicy.cs
@@ -1,0 +1,44 @@
+namespace Common.Services.Authentication;
+
+/// <summary>
+/// Computes escalating login lockout durations for the single admin account. Deliberately account-scoped
+/// (there is no per-IP tracking) - see <c>Services.Auth.Features.Auth.PostLoginEndpoint</c> for how this is
+/// applied.
+/// </summary>
+public static class LoginLockoutPolicy
+{
+    /// <summary>Number of consecutive failed attempts before a lockout starts.</summary>
+    public const int Threshold = 3;
+
+    private const double BaseSeconds = 10;
+    private const double GrowthFactor = 1.5;
+    private static readonly TimeSpan MaxLockout = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// The lockout duration for <paramref name="failedAttempts"/> consecutive failures, or <c>null</c> if that's
+    /// still below <see cref="Threshold"/>. Grows as <c>10s * 1.5^(failedAttempts - Threshold)</c>, capped at 1 day.
+    /// </summary>
+    public static TimeSpan? ComputeLockout(int failedAttempts)
+    {
+        if (failedAttempts < Threshold)
+            return null;
+
+        double seconds = BaseSeconds * Math.Pow(GrowthFactor, failedAttempts - Threshold);
+        return TimeSpan.FromSeconds(Math.Min(seconds, MaxLockout.TotalSeconds));
+    }
+
+    /// <summary>Formats a lockout duration for display, e.g. <c>"10s"</c>, <c>"1m 20s"</c>, <c>"3h 4m"</c>, <c>"1 day"</c>.</summary>
+    public static string Format(TimeSpan duration)
+    {
+        if (duration >= TimeSpan.FromDays(1))
+            return "1 day";
+
+        if (duration >= TimeSpan.FromHours(1))
+            return $"{(int)duration.TotalHours}h {duration.Minutes}m";
+
+        if (duration >= TimeSpan.FromMinutes(1))
+            return $"{(int)duration.TotalMinutes}m {duration.Seconds}s";
+
+        return $"{Math.Max((int)Math.Ceiling(duration.TotalSeconds), 1)}s";
+    }
+}

--- a/Common.Services/Authentication/PasswordHasher.cs
+++ b/Common.Services/Authentication/PasswordHasher.cs
@@ -8,6 +8,9 @@ namespace Common.Services.Authentication;
 /// </summary>
 public static class PasswordHasher
 {
+    /// <summary>Minimum accepted length for the admin password, enforced wherever it's set.</summary>
+    public const int MinPasswordLength = 8;
+
     private const int SaltSize = 16;
     private const int HashSize = 32;
     private const int Iterations = 210_000;

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ When adding a Komga library, the "Library Root Path" must be the path *inside th
 where Tranga's `Mangas` volume is mounted — not the path on the host, and not the path inside Tranga's own containers.
 Mount that same volume into your Komga container and point the field at wherever you mounted it (defaults to `/tranga` if left blank).
 
+### Resetting the admin password
+
+If `UseAuth` is enabled and you've forgotten the admin password, or the account is locked out after too many failed logins,
+run the `reset-password` tool shipped inside the auth container:
+
+```bash
+docker exec -it <auth-container> /app/reset-password
+```
+
+It prompts for a new password (input hidden, entered twice to confirm) and clears any active lockout.
+Leaving the prompt empty removes the password entirely, putting the deployment back into first-run setup —
+the login page will show the setup screen again on next load.
+
 ## Screenshots
 
 <img src="Screenshots/startpage.png" width="512" alt="start page"/>

--- a/Services.Auth.ResetPasswordTool.Tests/Helpers/AuthContextFactory.cs
+++ b/Services.Auth.ResetPasswordTool.Tests/Helpers/AuthContextFactory.cs
@@ -1,0 +1,26 @@
+using Common.Database.Auth;
+using Microsoft.EntityFrameworkCore;
+
+namespace Services.Auth.ResetPasswordTool.Tests.Helpers;
+
+/// <summary>
+/// Creates isolated <see cref="AuthContext"/> instances backed by a per-call temp-file Sqlite database for
+/// tests, mirroring Services.Auth.Tests/Helpers/AuthContextFactory.cs.
+/// </summary>
+public static class AuthContextFactory
+{
+    private static readonly string RootDirectory = Path.Combine(Path.GetTempPath(), "TrangaTests", "Services.Auth.ResetPasswordTool.Tests");
+
+    public static AuthContext Create()
+    {
+        Directory.CreateDirectory(RootDirectory);
+        string dbPath = Path.Combine(RootDirectory, $"{Guid.NewGuid():N}.db");
+        DbContextOptions<AuthContext> options = new DbContextOptionsBuilder<AuthContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+
+        AuthContext context = new(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+}

--- a/Services.Auth.ResetPasswordTool.Tests/ResetPasswordCommandTests.cs
+++ b/Services.Auth.ResetPasswordTool.Tests/ResetPasswordCommandTests.cs
@@ -1,0 +1,78 @@
+using Common.Database.Auth;
+using Common.Services.Authentication;
+using Common.Tests;
+using Microsoft.EntityFrameworkCore;
+using Services.Auth.ResetPasswordTool.Tests.Helpers;
+
+namespace Services.Auth.ResetPasswordTool.Tests;
+
+public class ResetPasswordCommandTests : TrangaTest
+{
+    [Fact]
+    public async Task SetPasswordAsync_WithNoExistingCredential_CreatesOne()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+
+        await ResetPasswordCommand.SetPasswordAsync(context, "new-password", ct);
+
+        DbCredential credential = await context.Credentials.SingleAsync(ct);
+        Assert.True(PasswordHasher.Verify("new-password", credential.PasswordHash));
+    }
+
+    [Fact]
+    public async Task SetPasswordAsync_WithExistingCredential_OverwritesPassword()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+        await context.Credentials.AddAsync(new DbCredential { PasswordHash = PasswordHasher.Hash("old-password") }, ct);
+        await context.SaveChangesAsync(ct);
+
+        await ResetPasswordCommand.SetPasswordAsync(context, "new-password", ct);
+
+        DbCredential credential = await context.Credentials.SingleAsync(ct);
+        Assert.True(PasswordHasher.Verify("new-password", credential.PasswordHash));
+        Assert.False(PasswordHasher.Verify("old-password", credential.PasswordHash));
+    }
+
+    [Fact]
+    public async Task SetPasswordAsync_ClearsExistingLockout()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+        await context.Credentials.AddAsync(
+            new DbCredential
+            {
+                PasswordHash = PasswordHasher.Hash("old-password"),
+                FailedLoginAttempts = 5,
+                LockedUntil = DateTimeOffset.UtcNow.AddHours(1),
+            },
+            ct);
+        await context.SaveChangesAsync(ct);
+
+        await ResetPasswordCommand.SetPasswordAsync(context, "new-password", ct);
+
+        DbCredential credential = await context.Credentials.SingleAsync(ct);
+        Assert.Equal(0, credential.FailedLoginAttempts);
+        Assert.Null(credential.LockedUntil);
+    }
+
+    [Fact]
+    public async Task RemoveCredentialAsync_WithExistingCredential_DeletesIt()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+        await context.Credentials.AddAsync(new DbCredential { PasswordHash = PasswordHasher.Hash("some-password") }, ct);
+        await context.SaveChangesAsync(ct);
+
+        await ResetPasswordCommand.RemoveCredentialAsync(context, ct);
+
+        Assert.False(await context.Credentials.AnyAsync(ct));
+    }
+
+    [Fact]
+    public async Task RemoveCredentialAsync_WithNoExistingCredential_DoesNotThrow()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+
+        await ResetPasswordCommand.RemoveCredentialAsync(context, ct);
+
+        Assert.False(await context.Credentials.AnyAsync(ct));
+    }
+}

--- a/Services.Auth.ResetPasswordTool.Tests/Services.Auth.ResetPasswordTool.Tests.csproj
+++ b/Services.Auth.ResetPasswordTool.Tests/Services.Auth.ResetPasswordTool.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
+        <PackageReference Include="Xunit.Combinatorial" Version="2.0.24" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Common.Tests\Common.Tests.csproj" />
+      <ProjectReference Include="..\Common.Database\Common.Database.csproj" />
+      <ProjectReference Include="..\Common.Services\Common.Services.csproj" />
+      <ProjectReference Include="..\Services.Auth.ResetPasswordTool\Services.Auth.ResetPasswordTool.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Services.Auth.ResetPasswordTool/Program.cs
+++ b/Services.Auth.ResetPasswordTool/Program.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using Common.Database.Auth;
+using Common.Database;
+using Common.Services.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Services.Auth.ResetPasswordTool;
+
+if (Console.IsInputRedirected)
+{
+    Console.Error.WriteLine("This tool needs an interactive terminal - re-run with:");
+    Console.Error.WriteLine("  docker exec -it <container> /app/reset-password");
+    return 1;
+}
+
+Console.WriteLine("Tranga admin password reset");
+Console.WriteLine("Leave the password empty to remove it instead - the app will show the first-run setup screen again.");
+Console.WriteLine();
+
+string? password = PromptForNewPassword();
+if (password is null)
+    return 1;
+
+DbContextOptionsBuilder<AuthContext> optionsBuilder = new();
+optionsBuilder.Configure(DatabaseContextOptionsBuilder.DbType.Postgresql);
+await using AuthContext context = new(optionsBuilder.Options);
+
+try
+{
+    if (password.Length == 0)
+    {
+        Console.Write("This removes the password entirely; anyone will be able to run setup again. Continue? [y/N] ");
+        string? confirm = Console.ReadLine();
+        if (!string.Equals(confirm?.Trim(), "y", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("Aborted, nothing changed.");
+            return 1;
+        }
+
+        await ResetPasswordCommand.RemoveCredentialAsync(context, CancellationToken.None);
+        Console.WriteLine("Password removed. The app will prompt for first-run setup on next load.");
+    }
+    else
+    {
+        await ResetPasswordCommand.SetPasswordAsync(context, password, CancellationToken.None);
+        Console.WriteLine("Password updated.");
+    }
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Failed to update the database: {ex.Message}");
+    return 1;
+}
+
+return 0;
+
+static string? PromptForNewPassword()
+{
+    const int maxTries = 3;
+    for (int attempt = 1; attempt <= maxTries; attempt++)
+    {
+        string first = ReadMaskedLine("New admin password (leave empty to remove it): ");
+        if (first.Length == 0)
+            return first;
+
+        if (first.Length < PasswordHasher.MinPasswordLength)
+        {
+            Console.WriteLine($"Password must be at least {PasswordHasher.MinPasswordLength} characters.");
+            continue;
+        }
+
+        string confirm = ReadMaskedLine("Confirm password: ");
+        if (first != confirm)
+        {
+            Console.WriteLine("Passwords did not match.");
+            continue;
+        }
+
+        return first;
+    }
+
+    Console.Error.WriteLine("Too many failed attempts.");
+    return null;
+}
+
+static string ReadMaskedLine(string prompt)
+{
+    Console.Write(prompt);
+    StringBuilder buffer = new();
+    while (true)
+    {
+        ConsoleKeyInfo key = Console.ReadKey(intercept: true);
+        if (key.Key == ConsoleKey.Enter)
+        {
+            Console.WriteLine();
+            return buffer.ToString();
+        }
+
+        if (key.Key == ConsoleKey.Backspace)
+        {
+            if (buffer.Length > 0)
+            {
+                buffer.Length--;
+                Console.Write("\b \b");
+            }
+            continue;
+        }
+
+        if (!char.IsControl(key.KeyChar))
+        {
+            buffer.Append(key.KeyChar);
+            Console.Write('*');
+        }
+    }
+}

--- a/Services.Auth.ResetPasswordTool/ResetPasswordCommand.cs
+++ b/Services.Auth.ResetPasswordTool/ResetPasswordCommand.cs
@@ -1,0 +1,45 @@
+using Common.Database.Auth;
+using Common.Services.Authentication;
+using Microsoft.EntityFrameworkCore;
+
+namespace Services.Auth.ResetPasswordTool;
+
+/// <summary>
+/// Core logic behind the <c>reset-password</c> CLI, kept separate from <c>Program</c>'s console I/O so it's
+/// unit-testable against an in-memory/Sqlite <see cref="AuthContext"/>.
+/// </summary>
+public static class ResetPasswordCommand
+{
+    /// <summary>Hashes and stores <paramref name="newPassword"/> as the admin credential, clearing any lockout.</summary>
+    public static async Task SetPasswordAsync(AuthContext context, string newPassword, CancellationToken ct)
+    {
+        DbCredential? existing = await context.Credentials.SingleOrDefaultAsync(ct);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        DbCredential updated = (existing ?? new DbCredential { CreatedAt = now }) with
+        {
+            PasswordHash = PasswordHasher.Hash(newPassword),
+            FailedLoginAttempts = 0,
+            LockedUntil = null,
+            UpdatedAt = now,
+        };
+
+        if (existing is null)
+            await context.Credentials.AddAsync(updated, ct);
+        else
+            context.Entry(existing).CurrentValues.SetValues(updated);
+
+        await context.SaveChangesAsync(ct);
+    }
+
+    /// <summary>Deletes the admin credential, if one exists, putting the deployment back into "not configured" state.</summary>
+    public static async Task RemoveCredentialAsync(AuthContext context, CancellationToken ct)
+    {
+        DbCredential? existing = await context.Credentials.SingleOrDefaultAsync(ct);
+        if (existing is null)
+            return;
+
+        context.Credentials.Remove(existing);
+        await context.SaveChangesAsync(ct);
+    }
+}

--- a/Services.Auth.ResetPasswordTool/Services.Auth.ResetPasswordTool.csproj
+++ b/Services.Auth.ResetPasswordTool/Services.Auth.ResetPasswordTool.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <InvariantGlobalization>true</InvariantGlobalization>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Common\Common.csproj" />
+      <ProjectReference Include="..\Common.Database\Common.Database.csproj" />
+      <ProjectReference Include="..\Common.Services\Common.Services.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Services.Auth.Tests/Features/Auth/PostLoginEndpointTests.cs
+++ b/Services.Auth.Tests/Features/Auth/PostLoginEndpointTests.cs
@@ -1,7 +1,9 @@
 using Common.Database.Auth;
 using Common.Services.Authentication;
 using Common.Tests;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
 using Services.Auth.Features.Auth;
 using Services.Auth.Tests.Helpers;
 
@@ -16,7 +18,7 @@ public class PostLoginEndpointTests : TrangaTest
         await context.Credentials.AddAsync(new DbCredential { PasswordHash = PasswordHasher.Hash("my-password") }, ct);
         await context.SaveChangesAsync(ct);
 
-        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult> result =
+        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult> result =
             await PostLoginEndpoint.Handle(context, new SetupRequest("my-password"), ct);
 
         Assert.IsType<Ok<AuthTokenResponse>>(result.Result);
@@ -29,7 +31,7 @@ public class PostLoginEndpointTests : TrangaTest
         await context.Credentials.AddAsync(new DbCredential { PasswordHash = PasswordHasher.Hash("my-password") }, ct);
         await context.SaveChangesAsync(ct);
 
-        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult> result =
+        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult> result =
             await PostLoginEndpoint.Handle(context, new SetupRequest("wrong-password"), ct);
 
         Assert.IsType<UnauthorizedHttpResult>(result.Result);
@@ -40,9 +42,78 @@ public class PostLoginEndpointTests : TrangaTest
     {
         await using AuthContext context = AuthContextFactory.Create();
 
-        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult> result =
+        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult> result =
             await PostLoginEndpoint.Handle(context, new SetupRequest("anything"), ct);
 
         Assert.IsType<UnauthorizedHttpResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Login_BelowLockoutThreshold_StillReturnsUnauthorized()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+        await context.Credentials.AddAsync(new DbCredential { PasswordHash = PasswordHasher.Hash("my-password") }, ct);
+        await context.SaveChangesAsync(ct);
+
+        for (int i = 0; i < LoginLockoutPolicy.Threshold - 1; i++)
+        {
+            Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult> result =
+                await PostLoginEndpoint.Handle(context, new SetupRequest("wrong-password"), ct);
+            Assert.IsType<UnauthorizedHttpResult>(result.Result);
+        }
+    }
+
+    [Fact]
+    public async Task Login_ReachingLockoutThreshold_ReturnsTooManyRequests()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+        await context.Credentials.AddAsync(new DbCredential { PasswordHash = PasswordHasher.Hash("my-password") }, ct);
+        await context.SaveChangesAsync(ct);
+
+        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult> result = default!;
+        for (int i = 0; i < LoginLockoutPolicy.Threshold; i++)
+            result = await PostLoginEndpoint.Handle(context, new SetupRequest("wrong-password"), ct);
+
+        ContentHttpResult content = Assert.IsType<ContentHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, content.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WhileLocked_RejectsEvenTheCorrectPassword()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+        await context.Credentials.AddAsync(new DbCredential { PasswordHash = PasswordHasher.Hash("my-password") }, ct);
+        await context.SaveChangesAsync(ct);
+
+        for (int i = 0; i < LoginLockoutPolicy.Threshold; i++)
+            await PostLoginEndpoint.Handle(context, new SetupRequest("wrong-password"), ct);
+
+        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult> result =
+            await PostLoginEndpoint.Handle(context, new SetupRequest("my-password"), ct);
+
+        ContentHttpResult content = Assert.IsType<ContentHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, content.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithCorrectPassword_ResetsFailedAttemptsAndLockout()
+    {
+        await using AuthContext context = AuthContextFactory.Create();
+        await context.Credentials.AddAsync(
+            new DbCredential
+            {
+                PasswordHash = PasswordHasher.Hash("my-password"),
+                FailedLoginAttempts = LoginLockoutPolicy.Threshold - 1,
+            },
+            ct);
+        await context.SaveChangesAsync(ct);
+
+        Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult> result =
+            await PostLoginEndpoint.Handle(context, new SetupRequest("my-password"), ct);
+
+        Assert.IsType<Ok<AuthTokenResponse>>(result.Result);
+        DbCredential updated = await context.Credentials.SingleAsync(ct);
+        Assert.Equal(0, updated.FailedLoginAttempts);
+        Assert.Null(updated.LockedUntil);
     }
 }

--- a/Services.Auth/Dockerfile
+++ b/Services.Auth/Dockerfile
@@ -8,6 +8,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Services.Auth/Services.Auth.csproj", "Services.Auth/"]
+COPY ["Services.Auth.ResetPasswordTool/Services.Auth.ResetPasswordTool.csproj", "Services.Auth.ResetPasswordTool/"]
 COPY ["Common.Services/Common.Services.csproj", "Common.Services/"]
 COPY ["Tranga.ServiceDefaults/Tranga.ServiceDefaults.csproj", "Tranga.ServiceDefaults/"]
 COPY ["Common/Common.csproj", "Common/"]
@@ -15,15 +16,23 @@ COPY ["Common.Database/Common.Database.csproj", "Common.Database/"]
 COPY ["Extensions/Extensions.csproj", "Extensions/"]
 COPY ["GeneratedExtensionClients/GeneratedExtensionClients.csproj", "GeneratedExtensionClients/"]
 RUN dotnet restore "Services.Auth/Services.Auth.csproj"
+RUN dotnet restore "Services.Auth.ResetPasswordTool/Services.Auth.ResetPasswordTool.csproj"
 COPY . .
 WORKDIR "/src/Services.Auth"
 RUN dotnet build "./Services.Auth.csproj" -c $BUILD_CONFIGURATION -o /app/build
+WORKDIR "/src/Services.Auth.ResetPasswordTool"
+RUN dotnet build "./Services.Auth.ResetPasswordTool.csproj" -c $BUILD_CONFIGURATION -o /app/build-tools
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./Services.Auth.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "/src/Services.Auth/Services.Auth.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "/src/Services.Auth.ResetPasswordTool/Services.Auth.ResetPasswordTool.csproj" -c $BUILD_CONFIGURATION -o /app/publish/tools /p:UseAppHost=false
 
 FROM base AS final
+USER root
 WORKDIR /app
 COPY --from=publish /app/publish .
+COPY ["Services.Auth/reset-password.sh", "/app/reset-password"]
+RUN chmod +x /app/reset-password
+USER $APP_UID
 ENTRYPOINT ["dotnet", "Services.Auth.dll"]

--- a/Services.Auth/Features/Auth/PostLoginEndpoint.cs
+++ b/Services.Auth/Features/Auth/PostLoginEndpoint.cs
@@ -12,20 +12,56 @@ namespace Services.Auth.Features.Auth;
 internal abstract class PostLoginEndpoint
 {
     /// <summary>
-    /// Logs in with the admin password, returning a session token.
+    /// Logs in with the admin password, returning a session token. Failed attempts are tracked on the
+    /// credential itself; after <see cref="LoginLockoutPolicy.Threshold"/> consecutive failures, further
+    /// attempts are rejected without checking the password until the escalating lockout window passes.
     /// </summary>
     /// <param name="authContext"></param>
     /// <param name="req"></param>
     /// <param name="ct"></param>
     /// <response code="200">Password matched; returns a session token</response>
     /// <response code="401">No password set up yet, or the password did not match</response>
-    public static async Task<Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult>> Handle(
+    /// <response code="429">Too many failed attempts; the response body says how long to wait</response>
+    public static async Task<Results<Ok<AuthTokenResponse>, UnauthorizedHttpResult, ContentHttpResult>> Handle(
         AuthContext authContext, [FromBody] SetupRequest req, CancellationToken ct)
     {
         DbCredential? credential = await authContext.Credentials.SingleOrDefaultAsync(ct);
-        if (credential is null || !PasswordHasher.Verify(req.Password, credential.PasswordHash))
+        if (credential is null)
             return TypedResults.Unauthorized();
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        if (credential.LockedUntil is { } lockedUntil && lockedUntil > now)
+            return LockedResult(lockedUntil - now);
+
+        if (!PasswordHasher.Verify(req.Password, credential.PasswordHash))
+        {
+            int failedAttempts = credential.FailedLoginAttempts + 1;
+            TimeSpan? lockout = LoginLockoutPolicy.ComputeLockout(failedAttempts);
+
+            authContext.Entry(credential).CurrentValues.SetValues(credential with
+            {
+                FailedLoginAttempts = failedAttempts,
+                LockedUntil = lockout is { } duration ? now + duration : null,
+            });
+            await authContext.SaveChangesAsync(ct);
+
+            return lockout is { } locked ? LockedResult(locked) : TypedResults.Unauthorized();
+        }
+
+        authContext.Entry(credential).CurrentValues.SetValues(credential with
+        {
+            FailedLoginAttempts = 0,
+            LockedUntil = null,
+            UpdatedAt = now,
+        });
+        await authContext.SaveChangesAsync(ct);
 
         return TypedResults.Ok(new AuthTokenResponse(JwtTokenService.CreateToken()));
     }
+
+    private static ContentHttpResult LockedResult(TimeSpan remaining) =>
+        TypedResults.Text(
+            $"Too many failed attempts. Try again in {LoginLockoutPolicy.Format(remaining)}.",
+            statusCode: StatusCodes.Status429TooManyRequests);
 }

--- a/Services.Auth/Features/Auth/PostSetupEndpoint.cs
+++ b/Services.Auth/Features/Auth/PostSetupEndpoint.cs
@@ -11,8 +11,6 @@ namespace Services.Auth.Features.Auth;
 /// </summary>
 internal abstract class PostSetupEndpoint
 {
-    private const int MinPasswordLength = 8;
-
     /// <summary>
     /// Creates the one admin password. Only works once - a password can't be replaced through this endpoint
     /// once one exists.
@@ -26,8 +24,8 @@ internal abstract class PostSetupEndpoint
     public static async Task<Results<Ok<AuthTokenResponse>, Conflict, BadRequest<string>>> Handle(
         AuthContext authContext, [FromBody] SetupRequest req, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(req.Password) || req.Password.Length < MinPasswordLength)
-            return TypedResults.BadRequest($"Password must be at least {MinPasswordLength} characters.");
+        if (string.IsNullOrWhiteSpace(req.Password) || req.Password.Length < PasswordHasher.MinPasswordLength)
+            return TypedResults.BadRequest($"Password must be at least {PasswordHasher.MinPasswordLength} characters.");
 
         if (await authContext.Credentials.AnyAsync(ct))
             return TypedResults.Conflict();

--- a/Services.Auth/reset-password.sh
+++ b/Services.Auth/reset-password.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec dotnet /app/tools/Services.Auth.ResetPasswordTool.dll "$@"

--- a/Tranga.sln
+++ b/Tranga.sln
@@ -47,6 +47,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Auth.Tests", "Serv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Services.Tests", "Common.Services.Tests\Common.Services.Tests.csproj", "{ECE6685E-C5D4-45C2-B19B-1A7FE1C72654}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Auth.ResetPasswordTool", "Services.Auth.ResetPasswordTool\Services.Auth.ResetPasswordTool.csproj", "{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Auth.ResetPasswordTool.Tests", "Services.Auth.ResetPasswordTool.Tests\Services.Auth.ResetPasswordTool.Tests.csproj", "{EE701BF3-2A2F-432F-BFDC-445698593C92}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -297,6 +301,30 @@ Global
 		{ECE6685E-C5D4-45C2-B19B-1A7FE1C72654}.Release|x64.Build.0 = Release|Any CPU
 		{ECE6685E-C5D4-45C2-B19B-1A7FE1C72654}.Release|x86.ActiveCfg = Release|Any CPU
 		{ECE6685E-C5D4-45C2-B19B-1A7FE1C72654}.Release|x86.Build.0 = Release|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Release|x64.Build.0 = Release|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6D6EAC1-C125-4B63-B8DB-E734D72B8421}.Release|x86.Build.0 = Release|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Debug|x64.Build.0 = Debug|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Debug|x86.Build.0 = Debug|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Release|x64.ActiveCfg = Release|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Release|x64.Build.0 = Release|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Release|x86.ActiveCfg = Release|Any CPU
+		{EE701BF3-2A2F-432F-BFDC-445698593C92}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Locks the admin account after 3 failed logins, with an escalating wait (x1.5 growth from 10s, capped at 1 day) tracked on the credential itself. Also ships a small interactive CLI in the Services.Auth docker image, runnable via `docker exec <container> /app/reset-password`, to set a new password or clear it entirely (forcing first-run setup again) when the admin is locked out or has forgotten it.