### PR TITLE
Show metadata source on manga overview

### DIFF
--- a/Frontend/app/components/Manga/Page.vue
+++ b/Frontend/app/components/Manga/Page.vue
@@ -29,6 +29,19 @@
                         <USkeleton v-else class="h-lh w-14" />
                         <UBadge v-if="manga?.metadataEntry?.nsfw" label="NSFW" color="error" variant="solid" />
                     </div>
+                    <UUser
+                        v-if="manga?.metadataEntry"
+                        :avatar="{
+                            src: metadataExtensions.getExtension(manga.metadataEntry.metadataExtensionId)?.iconUrl ?? '/blahaj.png',
+                        }"
+                        :name="
+                            metadataExtensions.getExtension(manga.metadataEntry.metadataExtensionId)?.name ??
+                            manga.metadataEntry.metadataExtensionId
+                        "
+                        :description="manga.metadataEntry.identifier"
+                        :to="manga.metadataEntry.url ?? undefined"
+                        target="_blank" />
+                    <USkeleton v-else class="h-lh w-32" />
                 </div>
 
                 <p v-if="$props.description">{{ $props.description }}</p>
@@ -56,6 +69,7 @@ import { releaseStatusBadgeColor } from '~/utils/releaseStatusBadgeColor';
 import type { NavigationMenuItem } from '@nuxt/ui/components/NavigationMenu.vue';
 import { ApiKeys } from '~/composables/ApiKeys';
 import type { TrangaPageTitleProps } from '~/components/Tranga/Page.vue';
+import useMetadataExtensions from '~/composables/MetadataExtension';
 
 export interface MangaPageProps {
     title?: string;
@@ -67,6 +81,8 @@ export interface MangaPageProps {
 const props = defineProps<MangaPageProps>();
 
 const displayTitle = computed(() => props.title ?? props.manga?.metadataEntry?.series);
+
+const { metadataExtensions } = await useMetadataExtensions();
 
 const { data: libraryMappings } = useTranga<GetLibrariesMappingsByMangaIdResponse>(() => `/libraries/mappings/${props.manga?.mangaId}`, {
     key: ApiKeys.Libraries.Mapping(props.manga?.mangaId ?? ''),


### PR DESCRIPTION
Adds a UUser element to the manga page sidebar, matching the pattern used in Metadata/ListCard.vue, so the source extension of the manga's chosen metadata entry is visible alongside title/status/description.