### PR TITLE
Update NuGet packages

### DIFF
--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -26,7 +26,7 @@ jobs:
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image-cuttingedge.yml
+++ b/.github/workflows/docker-image-cuttingedge.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@v4.3.0
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -26,7 +26,7 @@ jobs:
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@v4.3.0
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -26,7 +26,7 @@ jobs:
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@v4.3.0
       
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -30,6 +30,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql" Version="10.0.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -14,32 +14,32 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
-        <PackageReference Include="GitInfo" Version="3.6.0">
+        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.2.1" />
+        <PackageReference Include="GitInfo" Version="3.6.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+        <PackageReference Include="HtmlAgilityPack" Version="1.13.0" />
         <PackageReference Include="JikanDotNet" Version="2.10.4" />
         <PackageReference Include="LinkDotNet.BuildInformation" Version="2.1.5" />
         <PackageReference Include="log4net" Version="3.3.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="Npgsql" Version="10.0.1" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+        <PackageReference Include="Npgsql" Version="10.0.3" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-        <PackageReference Include="Soenneker.Utils.String.NeedlemanWunsch" Version="4.0.995" />
+        <PackageReference Include="Soenneker.Utils.String.NeedlemanWunsch" Version="4.0.997" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.3" />
-        <PackageReference Include="PuppeteerSharp" Version="20.2.5" />
-        <PackageReference Include="System.Drawing.Common" Version="10.0.10" />
+        <PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+        <PackageReference Include="System.Drawing.Common" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ The container also spins up a Swagger site at `http://<url>/swagger`.
 
 ## Star History
 
-<a href="https://star-history.com/#c9glax/tranga&Date">
+<a href="https://star-history.dera.page/#c9glax/tranga&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=c9glax/tranga&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=c9glax/tranga&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=c9glax/tranga&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=c9glax/tranga&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=c9glax/tranga&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=c9glax/tranga&type=Date" />
  </picture>
 </a>
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Bump most packages to their latest available versions. Two updates were skipped where "latest" broke the build:
- Microsoft.OpenApi kept at 2.7.5 (3.x conflicts with Microsoft.AspNetCore.OpenApi 10's <3.0.0 constraint)
- SixLabors.ImageSharp kept at 3.1.12 (4.x requires a commercial license)
- log4net kept at 3.3.2 (3.4.0 turns a non-fatal RollingFileAppender write failure into a build-breaking MSBuild error)
- xunit.v3/xunit.runner.visualstudio kept at 3.x (4.x requires opting into the new Microsoft Testing Platform, incompatible with the current VSTest-based dotnet test setup)