### PR TITLE
Fix Docker publish pipelines broken by GitInfo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 ﻿**/.dockerignore
 **/.env
-**/.git
 **/.gitignore
 **/.project
 **/.settings

--- a/.github/workflows/publish-frontend-image.yml
+++ b/.github/workflows/publish-frontend-image.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # full history + tags so git-describe (nuxt.config.ts) can derive an accurate version/commit
+          fetch-depth: 0
+          fetch-tags: true
 
       # https://github.com/marketplace/actions/push-to-ghcr
       - name: Build and publish a Docker image for ${{ github.repository }}

--- a/.github/workflows/publish-services_auth-image.yml
+++ b/.github/workflows/publish-services_auth-image.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # full history + tags so GitInfo (Common.Services/Service.cs) can derive an accurate version/commit
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Write Six Labors license
         run: echo "${{ secrets.SIXLABORS_LICENSE_B64 }}" | base64 -d > "${{ runner.temp }}/sixlabors.lic"

--- a/.github/workflows/publish-services_libraries-image.yml
+++ b/.github/workflows/publish-services_libraries-image.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # full history + tags so GitInfo (Common.Services/Service.cs) can derive an accurate version/commit
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Write Six Labors license
         run: echo "${{ secrets.SIXLABORS_LICENSE_B64 }}" | base64 -d > "${{ runner.temp }}/sixlabors.lic"

--- a/.github/workflows/publish-services_manga-image.yml
+++ b/.github/workflows/publish-services_manga-image.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # full history + tags so GitInfo (Common.Services/Service.cs) can derive an accurate version/commit
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Write Six Labors license
         run: echo "${{ secrets.SIXLABORS_LICENSE_B64 }}" | base64 -d > "${{ runner.temp }}/sixlabors.lic"

--- a/.github/workflows/publish-services_notifications-image.yml
+++ b/.github/workflows/publish-services_notifications-image.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # full history + tags so GitInfo (Common.Services/Service.cs) can derive an accurate version/commit
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Write Six Labors license
         run: echo "${{ secrets.SIXLABORS_LICENSE_B64 }}" | base64 -d > "${{ runner.temp }}/sixlabors.lic"

--- a/.github/workflows/publish-services_tasks-image.yml
+++ b/.github/workflows/publish-services_tasks-image.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # full history + tags so GitInfo (Common.Services/Service.cs) can derive an accurate version/commit
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Write Six Labors license
         run: echo "${{ secrets.SIXLABORS_LICENSE_B64 }}" | base64 -d > "${{ runner.temp }}/sixlabors.lic"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,12 @@
 <Project>
 
+    <PropertyGroup>
+        <!-- We only consume ThisAssembly.Git.* (see Common.Services/Service.cs) for logging/the /gitinfo endpoint.
+             GitInfo's own $(Version)/$(PackageVersion) assignment is disabled: it produces an invalid NuGet version
+             string (e.g. "0.0.0+main.") when git metadata isn't fully available, such as in the Docker build context. -->
+        <GitVersion>false</GitVersion>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="GitInfo" Version="3.6.1" PrivateAssets="all" />
     </ItemGroup>


### PR DESCRIPTION
GitInfo's automatic $(Version)/$(PackageVersion) assignment produced an invalid NuGet version string (e.g. "0.0.0+main.") whenever git metadata wasn't fully available, which is always the case in the Docker build context since .dockerignore excluded .git entirely. That auto-versioning was never intentional here (only ThisAssembly.Git.* is consumed), so disable it via Directory.Build.props.

Also let real git metadata reach the Docker build (un-ignore .git) and fetch full history/tags in the publish workflows, so the commit/branch/ version now visible via /gitinfo and startup logs are accurate in published images rather than blank.

Reproduced locally by building from a copy of the tree with .git removed (mirrors the Docker COPY context): NETSDK1018 with GitVersion=true, clean build with GitVersion=false.