### PR TITLE
Fix chapter release dates always being empty

### DIFF
--- a/Extensions.Tests/Extensions/MangaDexTests.cs
+++ b/Extensions.Tests/Extensions/MangaDexTests.cs
@@ -42,6 +42,8 @@ public sealed class MangaDexTests : DownloadExtensionTests<MangaDex>
         Assert.NotEmpty(chapters);
         Assert.True(chapters.Count > 100); // multiple pages
         Assert.Contains("249f2aa4-38a9-428f-8632-9a4aecc013ad", chapters.Select(c => c.Identifier));
+        ChapterInfo knownChapter = chapters.Single(c => c.Identifier == "249f2aa4-38a9-428f-8632-9a4aecc013ad");
+        Assert.NotNull(knownChapter.ReleaseDate);
     }
     
 

--- a/Extensions.Tests/Extensions/Suwayomi/SuwayomiSourceTests.cs
+++ b/Extensions.Tests/Extensions/Suwayomi/SuwayomiSourceTests.cs
@@ -165,4 +165,25 @@ public sealed class SuwayomiSourceTests : Common.Tests.TrangaTest
         Assert.False(SuwayomiSource.IsAdultContent(SuwayomiContentWarning.Safe, null));
         Assert.False(SuwayomiSource.IsAdultContent(SuwayomiContentWarning.Safe, []));
     }
+
+    [Fact]
+    public void ParseReleaseDateConvertsEpochMillisToDateTimeOffset()
+    {
+        // 2024-01-02T03:04:05Z
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1704164645),
+            SuwayomiSource.ParseReleaseDate(1704164645000));
+    }
+
+    [Fact]
+    public void ParseReleaseDateReturnsNullWhenZero()
+    {
+        // Suwayomi reports 0, not null, when a source doesn't provide an upload date.
+        Assert.Null(SuwayomiSource.ParseReleaseDate(0));
+    }
+
+    [Fact]
+    public void ParseReleaseDateReturnsNullWhenMissing()
+    {
+        Assert.Null(SuwayomiSource.ParseReleaseDate(null));
+    }
 }

--- a/Extensions/Data/ChapterInfo.cs
+++ b/Extensions/Data/ChapterInfo.cs
@@ -6,5 +6,6 @@ public sealed record ChapterInfo(
     string Url,
     string Identifier,
     string? Volume = null,
-    string? Title = null
+    string? Title = null,
+    DateTimeOffset? ReleaseDate = null
 );

--- a/Extensions/Extensions/MangaDex.cs
+++ b/Extensions/Extensions/MangaDex.cs
@@ -133,8 +133,11 @@ public sealed class MangaDex : IDownloadExtension, IMetadataExtension
             if (chapter.Attributes?.Chapter is not { } number)
                 continue;
             string url = $"https://mangadex.org/chapter/{id}";
+            DateTimeOffset? releaseDate = DateTimeOffset.TryParse(chapter.Attributes?.PublishAt, out DateTimeOffset parsed)
+                ? parsed
+                : null;
             result.Add(new ChapterInfo(this.Identifier, number, url, id.ToString(), chapter.Attributes?.Volume,
-                chapter.Attributes?.Title));
+                chapter.Attributes?.Title, releaseDate));
         }
 
         return result;

--- a/Extensions/Extensions/Suwayomi/SuwayomiClient.cs
+++ b/Extensions/Extensions/Suwayomi/SuwayomiClient.cs
@@ -36,7 +36,7 @@ internal static class SuwayomiClient
     private const string SourceFields = "id name lang displayName iconUrl homeUrl contentWarning supportsLatest";
     private const string ExtensionFields = "pkgName name lang iconUrl versionName contentWarning isInstalled isObsolete hasUpdate";
     private const string MangaFields = "id sourceId url title thumbnailUrl description author artist genre realUrl";
-    private const string ChapterFields = "id url name chapterNumber scanlator sourceOrder";
+    private const string ChapterFields = "id url name chapterNumber scanlator sourceOrder uploadDate";
 
     /// <summary>Server name/version, or <see langword="null"/> when the sidecar cannot be reached. Doubles as the reachability probe.</summary>
     internal static async Task<AboutServerPayload?> GetAboutAsync(CancellationToken ct) =>

--- a/Extensions/Extensions/Suwayomi/SuwayomiDtos.cs
+++ b/Extensions/Extensions/Suwayomi/SuwayomiDtos.cs
@@ -61,7 +61,8 @@ internal sealed record SuwayomiChapterDto(
     string? Name,
     double ChapterNumber,
     string? Scanlator,
-    int SourceOrder);
+    int SourceOrder,
+    long? UploadDate);
 
 internal sealed record SourcesData(SourceNodeList? Sources);
 

--- a/Extensions/Extensions/Suwayomi/SuwayomiSource.cs
+++ b/Extensions/Extensions/Suwayomi/SuwayomiSource.cs
@@ -222,7 +222,8 @@ public sealed class SuwayomiSource : IDownloadExtension
                 // The manga url is carried alongside the chapter url so a chapter can still be resolved when the
                 // sidecar has forgotten it (its ids are row ids, and only the urls are stable).
                 $"{mangaUrl}{IdentifierSeparator}{chapter.Url}",
-                Title: string.IsNullOrWhiteSpace(chapter.Name) ? null : chapter.Name))
+                Title: string.IsNullOrWhiteSpace(chapter.Name) ? null : chapter.Name,
+                ReleaseDate: ParseReleaseDate(chapter.UploadDate)))
             .ToList();
     }
 
@@ -231,6 +232,10 @@ public sealed class SuwayomiSource : IDownloadExtension
             ? chapter.ChapterNumber.ToString("0.####", CultureInfo.InvariantCulture)
             // Sources that do not expose a chapter number report -1; fall back to the source's own ordering.
             : (chapter.SourceOrder + 1).ToString(CultureInfo.InvariantCulture);
+
+    // Suwayomi reports 0, not null, when a source doesn't provide an upload date.
+    public static DateTimeOffset? ParseReleaseDate(long? uploadDateEpochMillis) =>
+        uploadDateEpochMillis is > 0 ? DateTimeOffset.FromUnixTimeMilliseconds(uploadDateEpochMillis.Value) : null;
 
     #endregion
 

--- a/Services.Manga.Tests/Helpers/MangaInfoHelperTests.cs
+++ b/Services.Manga.Tests/Helpers/MangaInfoHelperTests.cs
@@ -13,7 +13,9 @@ public class MangaInfoHelperTests
     public void ToChapter_ConvertsChapterInfoToDbChapterAndLinksManga()
     {
         DbManga manga = new() { MangaId = Guid.NewGuid(), Monitored = true };
-        ChapterInfo info = new(Guid.NewGuid(), "12", "https://example.com/12", "chapter-12", Volume: "2", Title: "Title");
+        DateTimeOffset releaseDate = DateTimeOffset.Parse("2024-01-02T03:04:05+00:00");
+        ChapterInfo info = new(Guid.NewGuid(), "12", "https://example.com/12", "chapter-12", Volume: "2",
+            Title: "Title", ReleaseDate: releaseDate);
 
         DbChapter chapter = info.ToChapter(manga);
 
@@ -23,6 +25,7 @@ public class MangaInfoHelperTests
         Assert.Equal("2", chapter.Volume);
         Assert.Equal("12", chapter.Number);
         Assert.Equal("Title", chapter.Title);
+        Assert.Equal(releaseDate, chapter.ReleaseDate);
         Assert.NotNull(chapter.DownloadLinks);
         Assert.Empty(chapter.DownloadLinks!);
     }

--- a/Services.Manga/Helpers/MangaInfoHelper.cs
+++ b/Services.Manga/Helpers/MangaInfoHelper.cs
@@ -23,6 +23,7 @@ public static class MangaInfoHelper
         Volume = info.Volume,
         Number = info.Number,
         Title = info.Title,
+        ReleaseDate = info.ReleaseDate,
         DownloadLinks = []
     };
 


### PR DESCRIPTION
ChapterInfo, the record extensions use to report chapter data, had no field to carry a release date, so it was always dropped even though MangaDex's PublishAt and Suwayomi's uploadDate expose one. Thread ReleaseDate through ChapterInfo, parse it in both extensions, and copy it onto DbChapter in MangaInfoHelper.ToChapter.


Claude-Session: https://claude.ai/code/session_01SU7sgPLG3NmByu79j3965E