### PR TITLE
Fix malformed JSON body in Pushover notification connector

### DIFF
--- a/API/Controllers/NotificationConnectorController.cs
+++ b/API/Controllers/NotificationConnectorController.cs
@@ -158,7 +158,7 @@ public class NotificationConnectorController(NotificationsContext context) : Con
             Name = createPushoverConnectorRecord.Name,
             Url = "https://api.pushover.net/1/messages.json",
             HttpMethod = "POST",
-            Body = $"{{\"token\": \"{createPushoverConnectorRecord.AppToken}\", \"user\": \"{createPushoverConnectorRecord.Username}\", \"message:\":\"%text\", \"%title\" }}",
+            Body = $"{{\"token\": \"{createPushoverConnectorRecord.AppToken}\", \"user\": \"{createPushoverConnectorRecord.Username}\", \"message\": \"%text\", \"title\": \"%title\"}}",
             Headers = new ()
         };
         return await CreateConnector(pushoverConnector);


### PR DESCRIPTION
CreatePushoverConnector built an invalid JSON body: the message key had a stray colon baked in ("message:") and the title was appended as a bare string with no key, causing Pushover's API to reject every request with "input was malformed and could not be parsed".

Fixes #529